### PR TITLE
Fix code block annotations

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -339,7 +339,7 @@ pub mod m1 {
 This example shows how one can use `allow` and `warn` to toggle a particular
 check on and off:
 
-```rust,ignore
+```rust
 #[warn(missing_docs)]
 pub mod m2{
     #[allow(missing_docs)]

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -17,7 +17,7 @@ apply to the item that follows the attribute.
 
 An example of attributes:
 
-```{.rust}
+```rust
 // General metadata applied to the enclosing module or crate.
 #![crate_type = "lib"]
 
@@ -164,8 +164,8 @@ macro scope.
 
 ## Miscellaneous attributes
 
-- `deprecated` - mark the item as deprecated; the full attribute is 
-  `#[deprecated(since = "crate version", note = "...")`, where both arguments 
+- `deprecated` - mark the item as deprecated; the full attribute is
+  `#[deprecated(since = "crate version", note = "...")`, where both arguments
   are optional.
 - `export_name` - on statics and functions, this determines the name of the
   exported symbol.
@@ -218,7 +218,7 @@ Configuration options are either provided by the compiler or passed in on the
 command line using `--cfg` (e.g. `rustc main.rs --cfg foo --cfg 'bar="baz"'`).
 Rust code then checks for their presence using the `#[cfg(...)]` attribute:
 
-```
+```rust
 // The function is only included in the build when compiling for macOS
 #[cfg(target_os = "macos")]
 fn macos_only() {
@@ -320,7 +320,7 @@ along with their default settings.  [Compiler
 plugins](../unstable-book/plugin.html#lint-plugins) can provide additional
 lint checks.
 
-```{.ignore}
+```rust,ignore
 pub mod m1 {
     // Missing documentation is ignored here
     #[allow(missing_docs)]
@@ -339,7 +339,7 @@ pub mod m1 {
 This example shows how one can use `allow` and `warn` to toggle a particular
 check on and off:
 
-```{.ignore}
+```rust,ignore
 #[warn(missing_docs)]
 pub mod m2{
     #[allow(missing_docs)]
@@ -361,7 +361,7 @@ pub mod m2{
 This example shows how one can use `forbid` to disallow uses of `allow` for
 that lint check:
 
-```{.ignore}
+```rust,ignore
 #[forbid(missing_docs)]
 pub mod m3 {
     // Attempting to toggle warning signals an error here
@@ -379,7 +379,7 @@ operations have to be easy for the compiler to find. The `lang` attribute
 makes it possible to declare these operations. For example, the `str` module
 in the Rust standard library defines the string equality function:
 
-```{.ignore}
+```rust,ignore
 #[lang = "str_eq"]
 pub fn eq_slice(a: &str, b: &str) -> bool {
     // details elided
@@ -419,7 +419,7 @@ for data structures. For example, the following will create an `impl` for the
 `PartialEq` and `Clone` traits for `Foo`, the type parameter `T` will be given
 the `PartialEq` or `Clone` constraints for the appropriate `impl`:
 
-```
+```rust
 #[derive(PartialEq, Clone)]
 struct Foo<T> {
     a: i32,
@@ -429,7 +429,7 @@ struct Foo<T> {
 
 The generated `impl` for `PartialEq` is equivalent to
 
-```
+```rust
 # struct Foo<T> { a: i32, b: T }
 impl<T: PartialEq> PartialEq for Foo<T> {
     fn eq(&self, other: &Foo<T>) -> bool {
@@ -454,7 +454,7 @@ considered a full-fledged language feature.
 
 For this reason, Rust recognizes a special crate-level attribute of the form:
 
-```{.ignore}
+```rust,ignore
 #![feature(feature1, feature2, feature3)]
 ```
 

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -89,7 +89,7 @@ A _literal expression_ consists of one of the [literal](tokens.html#literals) fo
 described earlier. It directly describes a number, character, string, boolean
 value, or the unit value.
 
-```text
+```rust
 ();        // unit type
 "hello";   // string type
 '5';       // character type

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -108,7 +108,7 @@ Tuples are written by enclosing zero or more comma-separated expressions in
 parentheses. They are used to create [tuple-typed](types.html#tuple-types)
 values.
 
-```{.tuple}
+```rust
 (0.0, 4.5);
 ("a", 4usize, true);
 ```
@@ -116,7 +116,7 @@ values.
 You can disambiguate a single-element tuple from a value in parentheses with a
 comma:
 
-```
+```rust
 (0,); // single-element tuple
 (0); // zero in parentheses
 ```
@@ -141,7 +141,7 @@ A _unit-like struct expression_ consists only of the [path](paths.html) of a
 
 The following are examples of struct expressions:
 
-```
+```rust
 # struct Point { x: f64, y: f64 }
 # struct NothingInMe { }
 # struct TuplePoint(f64, f64);
@@ -166,7 +166,7 @@ the same type as the base expression) with the given values for the fields that
 were explicitly specified and the values in the base expression for all other
 fields.
 
-```
+```rust
 # struct Point3d { x: i32, y: i32, z: i32 }
 let base = Point3d {x: 1, y: 2, z: 3};
 Point3d {y: 0, z: 10, .. base};
@@ -180,7 +180,7 @@ This allows a compact syntax with less duplication.
 
 Example:
 
-```
+```rust
 # struct Point3d { x: i32, y: i32, z: i32 }
 # let x = 0;
 # let y_value = 0;
@@ -199,13 +199,13 @@ the block itself.
 A block will execute each statement sequentially, and then execute the
 expression (if given). If the block ends in a statement, its value is `()`:
 
-```
+```rust
 let x: () = { println!("Hello."); };
 ```
 
 If it ends in an expression, its value and type are that of the expression:
 
-```
+```rust
 let x: i32 = { println!("Hello."); 5 };
 
 assert_eq!(5, x);
@@ -227,7 +227,7 @@ identifier, when not immediately followed by a parenthesized expression-list
 (the latter is a [method call expression](#method-call-expressions)). A field
 expression denotes a field of a [struct](types.html#struct-types).
 
-```{.ignore .field}
+```rust,ignore
 mystruct.myfield;
 foo().x;
 (Struct {a: 10, b: 20}).a;
@@ -252,7 +252,7 @@ In the `[expr ';' expr]` form, the expression after the `';'` must be a
 constant expression that can be evaluated at compile time, such as a
 [literal](tokens.html#literals) or a [static item](items.html#static-items).
 
-```
+```rust
 [1, 2, 3, 4];
 ["a", "b", "c", "d"];
 [0; 128];              // array with 128 zeros
@@ -271,7 +271,7 @@ bounds-checked at compile-time for constant arrays being accessed with a
 constant index value.  Otherwise a check will be performed at run-time that
 will put the thread in a _panicked state_ if it fails.
 
-```{should-fail}
+```rust,should_panic
 ([1, 2, 3, 4])[0];
 
 let x = (["a", "b"])[10]; // compiler error: const index-expr is out of bounds
@@ -292,7 +292,7 @@ autoderefs to more.
 
 The `..` operator will construct an object of one of the `std::ops::Range` variants.
 
-```
+```rust
 1..2;   // std::ops::Range
 3..;    // std::ops::RangeFrom
 ..4;    // std::ops::RangeTo
@@ -301,7 +301,7 @@ The `..` operator will construct an object of one of the `std::ops::Range` varia
 
 The following expressions are equivalent.
 
-```
+```rust
 let x = std::ops::Range {start: 0, end: 10};
 let y = 0..10;
 
@@ -311,7 +311,7 @@ assert_eq!(x, y);
 Similarly, the `...` operator will construct an object of one of the
 `std::ops::RangeInclusive` variants.
 
-```
+```rust
 # #![feature(inclusive_range_syntax)]
 1...2;   // std::ops::RangeInclusive
 ...4;    // std::ops::RangeToInclusive
@@ -319,7 +319,7 @@ Similarly, the `...` operator will construct an object of one of the
 
 The following expressions are equivalent.
 
-```
+```rust
 # #![feature(inclusive_range_syntax, inclusive_range)]
 let x = std::ops::RangeInclusive::NonEmpty {start: 0, end: 10};
 let y = 0...10;
@@ -464,7 +464,7 @@ on the right-hand side.
 
 An example of an `as` expression:
 
-```
+```rust
 # fn sum(values: &[f64]) -> f64 { 0.0 }
 # fn len(values: &[f64]) -> i32 { 0 }
 
@@ -493,7 +493,7 @@ Evaluating an assignment expression [either copies or
 moves](#moved-and-copied-types) its right-hand operand to its left-hand
 operand.
 
-```
+```rust
 # let mut x = 0;
 # let y = 0;
 x = y;
@@ -512,7 +512,7 @@ Any such expression always has the [`unit`](types.html#tuple-types) type.
 The precedence of Rust binary operators is ordered as follows, going from
 strong to weak:
 
-```{.text .precedence}
+```text
 as :
 * / %
 + -
@@ -540,7 +540,7 @@ within an expression.
 
 An example of a parenthesized expression:
 
-```
+```rust
 let x: i32 = (2 + 3) * 4;
 ```
 
@@ -553,7 +553,7 @@ eventually returns, then the expression completes.
 
 Some examples of call expressions:
 
-```
+```rust
 # fn add(x: i32, y: i32) -> i32 { 0 }
 
 let x: i32 = add(1i32, 2i32);
@@ -592,7 +592,7 @@ In this example, we define a function `ten_times` that takes a higher-order
 function argument, and we then call it with a lambda expression as an argument,
 followed by a lambda expression that moves values from its environment.
 
-```
+```rust
 fn ten_times<F>(f: F) where F: Fn(i32) {
     for index in 0..10 {
         f(index);
@@ -646,7 +646,7 @@ conditional expression evaluates to `false`, the `while` expression completes.
 
 An example:
 
-```
+```rust
 let mut i = 0;
 
 while i < 10 {
@@ -667,7 +667,7 @@ by an implementation of `std::iter::IntoIterator`.
 
 An example of a `for` loop over the contents of an array:
 
-```
+```rust
 # type Foo = i32;
 # fn bar(f: &Foo) { }
 # let a = 0;
@@ -683,7 +683,7 @@ for e in v {
 
 An example of a for loop over a series of integers:
 
-```
+```rust
 # fn bar(b:usize) { }
 for i in 0..256 {
     bar(i);
@@ -738,7 +738,7 @@ the inside of the match.
 
 An example of a `match` expression:
 
-```
+```rust
 let x = 1;
 
 match x {
@@ -759,7 +759,7 @@ bind to a reference by using the `ref` keyword, or to a mutable reference using
 Subpatterns can also be bound to variables by the use of the syntax `variable @
 subpattern`. For example:
 
-```
+```rust
 let x = 1;
 
 match x {
@@ -772,7 +772,7 @@ Patterns can also dereference pointers by using the `&`, `&mut` and `box`
 symbols, as appropriate. For example, these two matches on `x: &i32` are
 equivalent:
 
-```
+```rust
 # let x = &3;
 let y = match *x { 0 => "zero", _ => "some" };
 let z = match x { &0 => "zero", _ => "some" };
@@ -783,7 +783,7 @@ assert_eq!(y, z);
 Multiple match patterns may be joined with the `|` operator. A range of values
 may be specified with `...`. For example:
 
-```
+```rust
 # let x = 2;
 
 let message = match x {
@@ -802,7 +802,7 @@ criteria for matching a case. Pattern guards appear after the pattern and
 consist of a bool-typed expression following the `if` keyword. A pattern guard
 may refer to the variables bound within the pattern they follow.
 
-```
+```rust
 # let maybe_digit = Some(0);
 # fn process_digit(i: i32) { }
 # fn process_other(i: i32) { }
@@ -822,7 +822,7 @@ pattern. If the value of the expression on the right hand side of the `let`
 statement matches the pattern, the corresponding block will execute, otherwise
 flow proceeds to the first `else` block that follows.
 
-```
+```rust
 let dish = ("Ham", "Eggs");
 
 // this body will be skipped because the pattern is refuted
@@ -853,7 +853,7 @@ transfers control to the caller frame.
 
 An example of a `return` expression:
 
-```
+```rust
 fn max(a: i32, b: i32) -> i32 {
     if a > b {
         return a;

--- a/src/paths.md
+++ b/src/paths.md
@@ -14,7 +14,7 @@ crates; an item's canonical path merely identifies it within the crate.
 
 Two examples of simple paths consisting of only identifier components:
 
-```{.ignore}
+```rust,ignore
 x;
 x::y::z;
 ```

--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -9,7 +9,7 @@ would be due to type equality.
 Consider the following example: string literals always have `'static`
 lifetime. Nevertheless, we can assign `s` to `t`:
 
-```
+```rust
 fn bar<'a>() {
     let s: &'static str = "hi";
     let t: &'a str = s;

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -133,7 +133,7 @@ many `U+0023` (`#`) characters as were used to start the raw string literal) or
 
 Examples for string literals:
 
-```
+```rust
 "foo"; r"foo";                     // foo
 "\"foo\""; r#""foo""#;             // "foo"
 
@@ -197,7 +197,7 @@ many `U+0023` (`#`) characters as were used to start the raw string literal) or
 
 Examples for byte string literals:
 
-```
+```rust
 b"foo"; br"foo";                     // foo
 b"\"foo\""; br#""foo""#;             // "foo"
 
@@ -245,7 +245,7 @@ The type of an _unsuffixed_ integer literal is determined by type inference:
 
 Examples of integer literals of various forms:
 
-```
+```rust
 123i32;                            // type i32
 123u32;                            // type u32
 123_u32;                           // type u32
@@ -289,7 +289,7 @@ type inference:
 
 Examples of floating-point literals of various forms:
 
-```
+```rust
 123.0f64;        // type f64
 0.1f64;          // type f64
 0.1f32;          // type f32

--- a/src/types.md
+++ b/src/types.md
@@ -75,7 +75,7 @@ pattern-matching or by using `N` directly as a field to access the
 
 An example of a tuple type and its use:
 
-```
+```rust
 type Pair<'a> = (i32, &'a str);
 let p: Pair<'static> = (10, "ten");
 let (a, b) = p;
@@ -104,7 +104,7 @@ to, it borrows it.
 
 Examples:
 
-```{rust}
+```rust
 // A stack-allocated array
 let array: [i32; 3] = [1, 2, 3];
 
@@ -191,7 +191,7 @@ enclosing `enum` or `struct` type itself. Such recursion has restrictions:
 
 An example of a *recursive* type and its use:
 
-```
+```rust
 enum List<T> {
     Nil,
     Cons(T, Box<List<T>>)
@@ -238,7 +238,7 @@ or `extern`), a sequence of input types and an output type.
 
 An example of a `fn` type:
 
-```
+```rust
 fn add(x: i32, y: i32) -> i32 {
     x + y
 }
@@ -256,7 +256,7 @@ Internal to the compiler, there are also function types that are specific to a p
 function item. In the following snippet, for example, the internal types of the functions
 `foo` and `bar` are different, despite the fact that they have the same signature:
 
-```
+```rust
 fn foo() { }
 fn bar() { }
 ```
@@ -319,7 +319,7 @@ implementation of `R`, and the pointer value of `E`.
 
 An example of a trait object:
 
-```
+```rust
 trait Printable {
     fn stringify(&self) -> String;
 }
@@ -345,7 +345,7 @@ type signature of `print`, and the cast expression in `main`.
 Within the body of an item that has type parameter declarations, the names of
 its type parameters are types:
 
-```ignore
+```rust,ignore
 fn to_vec<A: Clone>(xs: &[A]) -> Vec<A> {
     if xs.is_empty() {
         return vec![];
@@ -366,7 +366,7 @@ The special type `Self` has a meaning within traits and impls. In a trait defini
 to an implicit type parameter representing the "implementing" type. In an impl,
 it is an alias for the implementing type. For example, in:
 
-```
+```rust
 pub trait From<T> {
     fn from(T) -> Self;
 }
@@ -381,7 +381,7 @@ impl From<i32> for String {
 The notation `Self` in the impl refers to the implementing type: `String`. In another
 example:
 
-```
+```rust
 trait Printable {
     fn make_string(&self) -> String;
 }

--- a/src/types.md
+++ b/src/types.md
@@ -345,7 +345,7 @@ type signature of `print`, and the cast expression in `main`.
 Within the body of an item that has type parameter declarations, the names of
 its type parameters are types:
 
-```rust,ignore
+```rust
 fn to_vec<A: Clone>(xs: &[A]) -> Vec<A> {
     if xs.is_empty() {
         return vec![];

--- a/src/variables.md
+++ b/src/variables.md
@@ -17,7 +17,7 @@ variable `y`).
 Methods that take either `self` or `Box<Self>` can optionally place them in a
 mutable variable by prefixing them with `mut` (similar to regular arguments):
 
-```
+```rust
 trait Changer: Sized {
     fn change(mut self) {}
     fn modify(mut self: Box<Self>) {}

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -19,7 +19,7 @@ items in a `pub` Trait are public by default; Enum variants
 in a `pub` enum are also public by default. When an item is declared as `pub`,
 it can be thought of as being accessible to the outside world. For example:
 
-```
+```rust
 # fn main() {}
 // Declare a private struct
 struct Foo;
@@ -79,7 +79,7 @@ scope.
 Here's an example of a program which exemplifies the three cases outlined
 above:
 
-```
+```rust
 // This module is private, meaning that no external crate can access this
 // module. Because it is private at the root of this current crate, however, any
 // module in the crate may access any publicly visible item in this module.
@@ -140,7 +140,7 @@ this is a public directive, this allows the item to be used in the current
 module through the rules above. It essentially allows public access into the
 re-exported item. For example, this program is valid:
 
-```
+```rust
 pub use self::implementation::api;
 
 mod implementation {


### PR DESCRIPTION
Fixes #3.
This makes all code blocks start with a name recognised by mdbook.