### PR TITLE
Explain block like expression statements

### DIFF
--- a/src/statements.md
+++ b/src/statements.md
@@ -36,7 +36,22 @@ declaration until the end of the enclosing block scope.
 
 ## Expression statements
 
-An _expression statement_ is one that evaluates an [expression](expressions.html)
-and ignores its result. The type of an expression statement `e;` is always
-`()`, regardless of the type of `e`. As a rule, an expression statement's
-purpose is to trigger the effects of evaluating its expression.
+An _expression statement_ is one that evaluates an
+[expression](expressions.html) and ignores its result. The type of an
+expression statement `e;` is always `()`, regardless of the type of `e`. As a
+rule, an expression statement's purpose is to trigger the effects of evaluating
+its expression. An expression that consists of only a [block
+expression](expressions.html#block-expressions) or control flow expression,
+that doesn't end a block and evaluates to `()` can also be used as an
+expression statement by omitting the trailing semicolon.
+
+```rust
+# let mut v = vec![1, 2, 3];
+v.pop();          // Ignore the element returned from pop
+if v.is_empty() {
+    v.push(5);
+} else {
+    v.remove(0);
+}                 // Semicolon can be omitted.
+[1];              // Separate expression statement, not an indexing expression.
+```


### PR DESCRIPTION
A small thing that I noticed while going through the expressions chapter. `unsafe` blocks also have this property, but I'm not sure if they should just be considered another kind of block.
Does this need an example?