### PR TITLE
Fix tidy on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf


### PR DESCRIPTION
This is exactly the same issue as https://github.com/rust-lang/book/pull/549, `x.py test src/tools/tidy` is failing again.
r? @steveklabnik @carols10cents