### PR TITLE
Document the `ignore` function attribute.

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -93,6 +93,7 @@ type int8_t = i8;
   item](#language-items) for more details.
 - `test` - indicates that this function is a test function, to only be compiled
   in case of `--test`.
+  - `ignore` - indicates that this test function is disabled.
 - `should_panic` - indicates that this test function should panic, inverting the success condition.
 - `cold` - The function is unlikely to be executed, so optimize it (and calls
   to it) differently.


### PR DESCRIPTION
This is very brief, without any usage or motivation. There's more
information in the 'Testing' section of the Rust Book.