### PR TITLE
Add diverging loops to diverging function section.

### DIFF
--- a/src/items.md
+++ b/src/items.md
@@ -365,9 +365,10 @@ fn my_err(s: &str) -> ! {
 ```
 
 We call such functions "diverging" because they never return a value to the
-caller. Every control path in a diverging function must end with a `panic!()` or
-a call to another diverging function on every control path. The `!` annotation
-does *not* denote a type.
+caller. Every control path in a diverging function must end with a `panic!()`,
+a loop expression without an associated break expression, or a call to another
+diverging function on every control path. The `!` annotation does *not* denote
+a type.
 
 It might be necessary to declare a diverging function because as mentioned
 previously, the typechecker checks that every control path in a function ends


### PR DESCRIPTION
I went with "corresponding break" here since you could have a
break that's inside another loop expression for the inner loop
expression, but that wouldn't change the divergence. That probably
needs to be better fleshed out, but I'd leave the fleshing out
of divergence to the loop item section of the reference.