### PR TITLE
Cleanup

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -72,13 +72,13 @@ The following expressions can create mutable lvalues:
 * [Temporary values](#temporary-lifetimes).
 * [Fields](#field-expressions), this evaluates the subexpression in a mutable
   lvalue context.
-* [Dereferenes](#the-dereference-operator) of a `*mut T` pointer.
+* [Dereferences](#the-dereference-operator) of a `*mut T` pointer.
 * Dereference of a variable, or field of a variable, with type `&mut T`. Note:
   this is an exception to the requirement for the next rule.
 * Dereferences of a type that implements `DerefMut`, this then requires that
   the value being dereferenced is evaluated is a mutable lvalue context.
 * [Indexing](#index-expressions) of a type that implements `DerefMut`, this
-  then evalutes the value being indexed (but not the index) in mutable lvalue
+  then evaluates the value being indexed (but not the index) in mutable lvalue
   context.
 
 ### Temporary lifetimes
@@ -168,7 +168,7 @@ also constant expressions:
 * [Paths](#path-expressions) to [functions](items.html#functions) and constants.
   Recursively defining constants is not allowed.
 * Paths to statics, so long as only their address, not their value, is used.
-  This includes using their value indirectly through a compilicated expression.
+  This includes using their value indirectly through a complicated expression.
   \*
 * [Tuple expressions](#tuple-expressions).
 * [Array expressions](#array-expressions).
@@ -441,8 +441,8 @@ A _field expression_ consists of an expression followed by a single dot and an
 [identifier](identifiers.html), when not immediately followed by a
 parenthesized expression-list (the latter is always a [method call
 expression](#method-call-expressions)). A field expression denotes a field of a
-[struct](types.html#struct-types). To call a function stored in a struct
-parentheses are needed around the field expression
+[struct](types.html#struct-types) or [union](items.html#unions). To call a
+function stored in a struct parentheses are needed around the field expression
 
 ```rust,ignore
 mystruct.myfield;
@@ -452,9 +452,9 @@ mystruct.method();          // Method expression
 (mystruct.function_field)() // Call expression containing a field expression
 ```
 
-A field access is an [lvalue](expressions.html#lvalues-and-rvalues) referring to the value of
-that field. When the subexpression is [mutable](#mutability), the field
-expression is also mutable.
+A field access is an [lvalue](expressions.html#lvalues-and-rvalues) referring
+to the location of that field. When the subexpression is
+[mutable](#mutability), the field expression is also mutable.
 
 Also, if the type of the expression to the left of the dot is a pointer, it is
 automatically dereferenced as many times as necessary to make the field access
@@ -482,7 +482,7 @@ let d: String = x.f3;           // Move out of x.f3
 ### Tuple indexing expressions
 
 [Tuples](types.html#tuple-types) and [struct tuples](items.html#structs) can be
-indexed using the number corresponding to the possition of the field. The index
+indexed using the number corresponding to the position of the field. The index
 must be written as a [decimal literal](tokens.html#integer-literals) with no
 underscores or suffix. Tuple indexing expressions also differ from field
 expressions in that they can unambiguously be called as a function. In all

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -267,7 +267,9 @@ the field values of a new instance of the struct. A field name can be any
 [identifier](identifiers.html), and is separated from its value expression by a
 colon. In the case of a tuple struct the field names are numbers corresponding
 to the position of the field. The numbers must be written in decimal,
-containing no underscores and with no leading zeros or integer suffix.
+containing no underscores and with no leading zeros or integer suffix. A value
+of a [union](items.html#unions) type can also be created using this syntax,
+except that it must specify exactly one field.
 
 Struct expressions can't be used directly in the head of a [loop](#loops) or an
 [`if`](#if-expressions), [`if let`](#if-let-expressions) or

--- a/src/items.md
+++ b/src/items.md
@@ -591,7 +591,7 @@ struct types, except that it must specify exactly one field:
 
 ```rust
 # union MyUnion { f1: u32, f2: f32 }
-
+#
 let u = MyUnion { f1: 1 };
 ```
 
@@ -612,7 +612,7 @@ union fields have to be placed in `unsafe` blocks.
 ```rust
 # union MyUnion { f1: u32, f2: f32 }
 # let u = MyUnion { f1: 1 };
-
+#
 unsafe {
     let f = u.f1;
 }
@@ -624,7 +624,7 @@ so these writes don't have to be placed in `unsafe` blocks
 ```rust
 # union MyUnion { f1: u32, f2: f32 }
 # let mut u = MyUnion { f1: 1 };
-
+#
 u.f1 = 2;
 ```
 
@@ -639,7 +639,7 @@ to be placed in `unsafe` blocks as well.
 
 ```rust
 # union MyUnion { f1: u32, f2: f32 }
-
+#
 fn f(u: MyUnion) {
     unsafe {
         match u {

--- a/src/items.md
+++ b/src/items.md
@@ -715,11 +715,13 @@ More detailed specification for unions, including unstable bits, can be found in
 
 ## Constant items
 
-A *constant item* is a named _constant value_ which is not associated with a
+A *constant item* is a named _[constant value]_ which is not associated with a
 specific memory location in the program. Constants are essentially inlined
 wherever they are used, meaning that they are copied directly into the relevant
 context when used. References to the same constant are not necessarily
 guaranteed to refer to the same memory address.
+
+[constant value]: expressions.html#constant-expressions
 
 Constant values must not have destructors, and otherwise permit most forms of
 data. Constants may refer to the address of other constants, in which case the

--- a/src/linkage.md
+++ b/src/linkage.md
@@ -132,8 +132,8 @@ The standard library in general strives to support both statically linked and
 dynamically linked C runtimes for targets as appropriate. For example the
 `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-musl` targets typically come
 with both runtimes and the user selects which one they'd like. All targets in
-the compiler have a default mode of linking to the C runtime. Typicall targets
-linked dynamically by default, but there are exceptions which are static by
+the compiler have a default mode of linking to the C runtime. Typically targets
+are linked dynamically by default, but there are exceptions which are static by
 default such as:
 
 * `arm-unknown-linux-musleabi`

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -12,7 +12,8 @@ grammar as double-quoted strings. Other tokens have exact rules given.
 A literal is an expression consisting of a single token, rather than a sequence
 of tokens, that immediately and directly denotes the value it evaluates to,
 rather than referring to it by name or some other evaluation rule. A literal is
-a form of constant expression, so is evaluated (primarily) at compile time.
+a form of [constant expression](expressions.html#constant-expressions), so is
+evaluated (primarily) at compile time.
 
 ### Examples
 


### PR DESCRIPTION
* Fixes some spelling errors
* Hides some blank lines at the start of code blocks
* Link to the constant expression section where relevant
* Mention unions with struct expressions