### PR TITLE
ignore doctest of `extern "stdcall"` on non-x86

### DIFF
--- a/src/items.md
+++ b/src/items.md
@@ -416,6 +416,7 @@ modifier.
 extern fn new_i32() -> i32 { 0 }
 
 // Declares an extern fn with "stdcall" ABI
+# #[cfg(target_arch = "x86_64")]
 extern "stdcall" fn new_i32_stdcall() -> i32 { 0 }
 ```
 


### PR DESCRIPTION
The "stdcall" ABI only exists on x86, so this causes tests to fail on
other architectures. This should fix rust-lang/rust#40260 next time we
update the reference.