### PR TITLE
Update description of `rustc_on_unimplemented`

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -206,8 +206,10 @@ macro scope.
    You may use format arguments like `{T}`, `{A}` to correspond to the
    types at the point of use corresponding to the type parameters of the
    trait of the same name. `{Self}` will be replaced with the type that is supposed
-   to implement the trait but doesn't. To use this, the `on_unimplemented` feature gate
-   must be enabled.
+   to implement the trait but doesn't. You can also use the trait's name which will
+   be replaced with the full path for the trait, for example for the trait `Foo` in
+   module `Bar`, `{Foo}` can be used and will show up as `Bar::Foo`.
+   To use this, the `on_unimplemented` feature gate must be enabled.
 - `must_use` - on structs and enums, will warn if a value of this type isn't used or
    assigned to a variable. You may also include an optional message by using
    `#[must_use = "message"]` which will be given alongside the warning.


### PR DESCRIPTION
Add description of new feature: substitute `{TraitName}` with full path
for the trait implemented in https://github.com/rust-lang/rust/pull/43000.