### PR TITLE
Clarify that breaking the Pointer Aliasing Rules requires an access

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -10,7 +10,7 @@ the guarantee that these issues are never caused by safe code.
   (uninitialized) memory
 * Breaking the [pointer aliasing
   rules](http://llvm.org/docs/LangRef.html#pointer-aliasing-rules)
-  with raw pointers (a subset of the rules used by C)
+  on accesses through raw pointers (a subset of the rules used by C)
 * `&mut T` and `&T` follow LLVM’s scoped [noalias] model, except if the `&T`
   contains an `UnsafeCell<U>`. Unsafe code must not violate these aliasing
   guarantees.


### PR DESCRIPTION
This clarifies that you must access a pointer to violate LLVM's Pointer Aliasing Rules.

From a discussion today on #rust with @ubsan and @rkruppe