### PR TITLE
Clarify that address leaks aren't considered unsafe

### DIFF
--- a/src/behavior-not-considered-unsafe.md
+++ b/src/behavior-not-considered-unsafe.md
@@ -7,6 +7,7 @@ or erroneous.
 ##### Deadlocks
 ##### Leaks of memory and other resources
 ##### Exiting without calling destructors
+##### Exposing randomized base addresses through pointer leaks
 ##### Integer overflow
 
 If a program contains arithmetic overflow, the programmer has made an


### PR DESCRIPTION
This explicitly adds leaking of randomized base addresses as not being considered unsafe.

From a discussion on #rust today with @ubsan and @rkruppe