### PR TITLE
The unit value is not a literal, it is a tuple expression

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -232,10 +232,9 @@ exist in `core::ops` and `core::cmp` with the same names.
 
 A _literal expression_ consists of one of the [literal](tokens.html#literals)
 forms described earlier. It directly describes a number, character, string,
-boolean value, or the unit value.
+or boolean value.
 
 ```rust
-();        // unit type
 "hello";   // string type
 '5';       // character type
 5;         // integer type
@@ -272,6 +271,7 @@ values.
 ```rust
 (0.0, 4.5);
 ("a", 4usize, true);
+();
 ```
 
 You can disambiguate a single-element tuple from a value in parentheses with a


### PR DESCRIPTION
As can be seen [on the AST](https://github.com/rust-lang/rust/blob/51cd06170eccf91a2d93018e939473a8db18da92/src/libsyntax/ast.rs#L1114).