### PR TITLE
Small fixes to the expressions section

### DIFF
--- a/src/expressions/field-expr.md
+++ b/src/expressions/field-expr.md
@@ -23,15 +23,16 @@ Also, if the type of the expression to the left of the dot is a pointer, it is
 automatically dereferenced as many times as necessary to make the field access
 possible. In cases of ambiguity, we prefer fewer autoderefs to more.
 
-Finally the fields of a struct, a reference to a struct are treated as separate
-entities when borrowing. If the struct does not implement
-[`Drop`](the-drop-trait.html) this also applies to moving out of each of its fields
-where possible. This also does not apply if automatic dereferencing is done
-though user defined types.
+Finally, the fields of a struct or a reference to a struct are treated as
+separate entities when borrowing. If the struct does not implement
+[`Drop`](the-drop-trait.html) and is stored in a local variable, this also
+applies to moving out of each of its fields. This also does not apply if
+automatic dereferencing is done though user defined types.
 
 ```rust
-# struct A { f1: String, f2: String, f3: String }
-# let mut x = A {
+struct A { f1: String, f2: String, f3: String }
+let mut x: A;
+# x = A {
 #     f1: "f1".to_string(),
 #     f2: "f2".to_string(),
 #     f3: "f3".to_string()

--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -15,7 +15,8 @@ let log_pi = pi.unwrap_or(1.0).log(2.72);
 ```
 
 When resolving method calls on an expression of type `A`, Rust will use the
-following order:
+following order, only looking at methods that are
+[visible](#visibility-and-privacy.html) and traits that are in scope:
 
 1. Inherent methods, with receiver of type `A`, `&A`, `&mut A`.
 1. Trait methods with receiver of type `A`.

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -331,29 +331,3 @@ let mut x = 10;
 x += 4;
 assert_eq!(x, 14);
 ```
-
-## Operator precedence
-
-The precedence of Rust operators is ordered as follows, going from strong to
-weak. Binary Operators at the same precedence level are evaluated in the order
-given by their associativity.
-
-
-| Operator                    | Associativity       |
-|-----------------------------|---------------------|
-| `?`                         |                     |
-| Unary `-` `*` `!` `&` `&mut` |                    |
-| `as` `:`                    | left to right       |
-| `*` `/` `%`                 | left to right       |
-| `+` `-`                     | left to right       |
-| `<<` `>>`                   | left to right       |
-| `&`                         | left to right       |
-| `^`                         | left to right       |
-| <code>&#124;</code>         | left to right       |
-| `==` `!=` `<` `>` `<=` `>=` | Require parentheses |
-| `&&`                        | left to right       |
-| <code>&#124;&#124;</code>   | left to right       |
-| `..` `...`                  | Require parentheses |
-| `<-`                        | right to left       |
-| `=` `+=` `-=` `*=` `/=` `%=` <br> `&=` <code>&#124;=</code> `^=` `<<=` `>>=` | right to left |
-

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -14,7 +14,10 @@ statics:
 * Statics may not contain any destructors.
 * The types of static values must ascribe to `Sync` to allow thread-safe
   access.
-* Statics may not refer to other statics by value, only by reference.
+* Statics allow using paths to statics in the
+  [constant-expression](#expresions.html#constant-expressions) used to
+  initialize them, but statics may not refer to other statics by value, only by
+  reference.
 * Constants cannot refer to statics.
 
 Constants should in general be preferred over statics, unless large amounts of


### PR DESCRIPTION
A number of small changes to the expressions section.

* Extend the operator precedence section to be expression precedence (Fixes #107)
* Improve constant expressions (Fixes #120)
* Don't (incorrectly) imply that one can move out of the fields of a boxed struct separately.
* Mention that methods that aren't visible aren't used in type resolution.
* Expressions bound to patterns are always lvalues (so can be unsized) even when moved from.