### PR TITLE
Canonical Paths

### DIFF
--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -6,8 +6,6 @@ wherever they are used, meaning that they are copied directly into the relevant
 context when used. References to the same constant are not necessarily
 guaranteed to refer to the same memory address.
 
-[constant value]: expressions.html#constant-expressions
-
 Constant values must not have destructors, and otherwise permit most forms of
 data. Constants may refer to the address of other constants, in which case the
 address will have elided lifetimes where applicable, otherwise – in most cases
@@ -15,13 +13,9 @@ address will have elided lifetimes where applicable, otherwise – in most cases
 elision].) The compiler is, however, still at liberty to translate the constant
 many times, so the address referred to may not be stable.
 
-[static lifetime elision]: items/static-items.html#static-lifetime-elision
-
 Constants must be explicitly typed. The type may be any type that doesn't
 implement [`Drop`] and has a `'static` lifetime: any references it contains
 must have `'static` lifetimes.
-
-[`Drop`]: the-drop-trait.html
 
 ```rust
 const BIT1: u32 = 1 << 0;
@@ -40,3 +34,7 @@ const BITS_N_STRINGS: BitsNStrings<'static> = BitsNStrings {
     mystring: STRING,
 };
 ```
+
+[constant value]: expressions.html#constant-expressions
+[static lifetime elision]: items/static-items.html#static-lifetime-elision
+[`Drop`]: the-drop-trait.html

--- a/src/paths.md
+++ b/src/paths.md
@@ -5,9 +5,6 @@ a namespace qualifier (`::`). If a path consists of only one component, it may
 refer to either an [item] or a [variable] in a local control
 scope. If a path has multiple components, it refers to an item.
 
-[item]: items.html
-[variable]: variables.html
-
 Every item has a _canonical path_ within its crate, but the path naming an item
 is only meaningful within a given crate. There is no global namespace across
 crates; an item's canonical path merely identifies it within the crate.
@@ -19,15 +16,11 @@ x;
 x::y::z;
 ```
 
-Path components are usually [identifiers], but they may
-also include angle-bracket-enclosed lists of type arguments. In
-[expression] context, the type argument list is given
-after a `::` namespace qualifier in order to disambiguate it from a
-relational expression involving the less-than symbol (`<`). In type
-expression context, the final namespace qualifier is omitted.
-
-[identifiers]: identifiers.html
-[expression]: expressions.html
+Path components are usually [identifiers], but they may also include
+angle-bracket-enclosed lists of type arguments. In [expression] context, the
+type argument list is given after a `::` namespace qualifier in order to
+disambiguate it from a relational expression involving the less-than symbol
+(`<`). In type expression context, the final namespace qualifier is omitted.
 
 Two examples of paths with type arguments:
 
@@ -103,3 +96,8 @@ mod a {
 }
 # fn main() {}
 ```
+
+[item]: items.html
+[variable]: variables.html
+[identifiers]: identifiers.html
+[expression]: expressions.html


### PR DESCRIPTION
Defines canonical paths, as part of #129.

Note to reviewer(s): There's also two commits that just change the location of links and change where newlines are, so just focus on the giant green blob in the paths file.