### PR TITLE
Array and indexing grammar

### DIFF
--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -54,6 +54,9 @@ _panicked state_ if it fails.
 ```rust,should_panic
 ([1, 2, 3, 4])[2];        // Evaluates to 3
 
+let b = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+b[1][2];                  // multidimensional array indexing
+
 let x = (["a", "b"])[10]; // warning: const index-expr is out of bounds
 
 let n = 10;
@@ -61,9 +64,6 @@ let y = (["a", "b"])[n];  // panics
 
 let arr = ["a", "b"];
 arr[10];                  // panics
-
-# let b = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
-b[1][2];                  // multidimensional array indexing
 ```
 
 The array index expression can be implemented for types other than arrays and slices

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -2,6 +2,12 @@
 
 ## Array expressions
 
+> **<sup>Syntax</sup>**  
+> _ArrayExpression_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; `[`  `]`  
+> &nbsp;&nbsp; | `[` [_Expression_] ( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup> `]`  
+> &nbsp;&nbsp; | `[` [_Expression_] `;` [_Expression_] `]`  
+
 An _[array](types.html#array-and-slice-types) expression_ can be written by
 enclosing zero or more comma-separated expressions of uniform type in square
 brackets. This produces and array containing each of these values in the
@@ -20,10 +26,15 @@ greater than 1 then this requires that the type of `a` is
 [1, 2, 3, 4];
 ["a", "b", "c", "d"];
 [0; 128];              // array with 128 zeros
-[0u8, 0u8, 0u8, 0u8];
+[0u8, 0u8, 0u8, 0u8,];
+[[1, 0, 0], [0, 1, 0], [0, 0, 1]]; // 2D array
 ```
 
 ## Array and slice indexing expressions
+
+> **<sup>Syntax</sup>**  
+> _IndexExpression_ :  
+> &nbsp;&nbsp; [_Expression_] `[` [_Expression_] `]`
 
 [Array and slice](types.html#array-and-slice-types)-typed expressions can be
 indexed by writing a square-bracket-enclosed expression (the index) after them.
@@ -50,4 +61,14 @@ let y = (["a", "b"])[n];  // panics
 
 let arr = ["a", "b"];
 arr[10];                  // panics
+
+# let b = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+b[1][2];                  // multidimensional array indexing
 ```
+
+The array index expression can be implemented for types other than arrays and slices
+by implementing the [Index] and [IndexMut] traits.
+
+[Index]: https://doc.rust-lang.org/std/ops/trait.Index.html
+[IndexMut]: https://doc.rust-lang.org/std/ops/trait.IndexMut.html
+[_Expression_]: expressions.html


### PR DESCRIPTION
Also, add the information that the indexing expressions can be made available in other types by implementing `Index` and `IndexMut`.

Part of #84.