### PR TITLE
Remove unstable and 'in the future' things.

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -5,7 +5,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; [`a`-`z` `A`-`Z`]&nbsp;[`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>\*</sup>  
 > &nbsp;&nbsp; | `_` [`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>+</sup>  
 
-An identifier is any nonempty ASCII[^non_ascii_idents] string of the following form:
+An identifier is any nonempty ASCII string of the following form:
 
 Either
 
@@ -17,5 +17,3 @@ Or
    * The first character is `_`
    * The identifier is more than one character, `_` alone is not an identifier
    * The remaining characters are alphanumeric or `_`
-
-[^non_ascii_idents] Non-ASCII characters in identifiers are currently feature-gated. See [issue #28979](https://github.com/rust-lang/rust/issues/28979).

--- a/src/macros.md
+++ b/src/macros.md
@@ -4,13 +4,10 @@ A number of minor features of Rust are not central enough to have their own
 syntax, and yet are not implementable as functions. Instead, they are given
 names, and invoked through a consistent syntax: `some_extension!(...)`.
 
-Users of `rustc` can define new macros in two ways:
+Thre are two ways to define new macros:
 
-* [Macros by Example] define new syntax in a higher-level,
-  declarative way.
+* [Macros by Example] define new syntax in a higher-level, declarative way.
 * [Procedural Macros] can be used to implement custom derive.
-
-And one unstable way: [compiler plugins].
 
 [Macros by Example]: macros-by-example.html
 [Procedural Macros]: procedural-macros.html

--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -1,10 +1,8 @@
 ## Procedural Macros
 
-"Procedural macros" are the second way to implement a macro. For now, the only
-thing they can be used for is to implement derive on your own types. See
-[the book][procedural macros] for a tutorial.
-
-[procedural macros]: ../book/procedural-macros.html
+*Procedural macros* allow creating syntax extensions as execution of a function.
+Procedural macros can be used for is to implement custom [derive] on your own
+types. See [the book][procedural macros] for a tutorial.
 
 Procedural macros involve a few different parts of the language and its
 standard libraries. First is the `proc_macro` crate, included with Rust,
@@ -21,3 +19,6 @@ pub fn hello_world(input: TokenStream) -> TokenStream
 
 Finally, procedural macros must be in their own crate, with the `proc-macro`
 crate type.
+
+[derive]: attributes.html#derive
+[procedural macros]: ../book/first-edition/procedural-macros.html

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -142,8 +142,8 @@ Coercion is allowed between the following types:
     - coerce_inner(`T`) = `U` where `T` is a concrete type which implements the
     trait `U`.
 
-    In the future, coerce_inner will be recursively extended to tuples and
+    <!--In the future, coerce_inner will be recursively extended to tuples and
     structs. In addition, coercions from sub-traits to super-traits will be
-    added. See [RFC 401] for more details.
+    added. See [RFC 401] for more details.-->
 
 * Non capturing closures to `fn` pointers

--- a/src/types.md
+++ b/src/types.md
@@ -301,8 +301,8 @@ which are only assigned when the function is called) - so the value does not
 need to contain an actual function pointer, and no indirection is needed when
 the function is called.
 
-There is currently no syntax that directly refers to a function item type, but
-the compiler will display the type as something like `fn() {foo::<u32>}` in
+There is no syntax that directly refers to a function item type, but the
+compiler will display the type as something like `fn(u32) -> i32 {fn_name}` in
 error messages.
 
 Because the function item type explicitly identifies the function, the item


### PR DESCRIPTION
The `Compiler Features` section should be moved to the Unstable book.

I've currently commented out the section on Type Coercions because I cannot parse what it's saying right now to check if it's up to date. (Yay, sleepiness.) If anybody else wants to tell me what that is saying, I'd be grateful.

There were two other changes made in this PR, just because I was there. The first is updating what the fake type shown by rustc is for function item types. The second is that I added attributes on unions and added repr to it. This is mainly to make me not forget about unions when I get to making a representations section.

Fixes #119.