### PR TITLE
Rename lvalue and rvalue to place and value expressions

### DIFF
--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -38,7 +38,7 @@ greater than 1 then this requires that the type of `a` is
 
 [Array and slice](types.html#array-and-slice-types)-typed expressions can be
 indexed by writing a square-bracket-enclosed expression (the index) after them.
-When the array is mutable, the resulting [place] can be assigned to.
+When the array is mutable, the resulting [memory location] can be assigned to.
 For other types an index expression `a[b]` is equivalent to
 `*std::ops::Index::index(&a, b)`, or `*std::opsIndexMut::index_mut(&mut a, b)`
 in a mutable place expression context. Just as with methods, Rust will also
@@ -69,7 +69,7 @@ The array index expression can be implemented for types other than arrays and sl
 by implementing the [Index] and [IndexMut] traits.
 
 [_Expression_]: expressions.html
-[place]: expressions.html#place-expressions-and-value-expressions
+[memory location]: expressions.html#place-expressions-and-value-expressions
 [Index]: ../std/ops/trait.Index.html
 [IndexMut]: ../std/ops/trait.IndexMut.html
 [constant expression]: expressions.html#constant-expressions

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -38,18 +38,17 @@ greater than 1 then this requires that the type of `a` is
 
 [Array and slice](types.html#array-and-slice-types)-typed expressions can be
 indexed by writing a square-bracket-enclosed expression (the index) after them.
-When the array is mutable, the resulting
-[lvalue](expressions.html#lvalues-and-rvalues) can be assigned to.
+When the array is mutable, the resulting [place] can be assigned to.
 For other types an index expression `a[b]` is equivalent to
 `*std::ops::Index::index(&a, b)`, or `*std::opsIndexMut::index_mut(&mut a, b)`
-in a mutable lvalue context. Just as with methods, Rust will also insert
-dereference operations on `a` repeatedly to find an implementation.
+in a mutable place expression context. Just as with methods, Rust will also
+insert dereference operations on `a` repeatedly to find an implementation.
 
 Indices are zero-based, and are of type `usize` for arrays and slices. Array
-access is a [constant expression](expressions.html#constant-expressions), so bounds can be
-checked at compile-time for constant arrays with a constant index value.
-Otherwise a check will be performed at run-time that will put the thread in a
-_panicked state_ if it fails.
+access is a [constant expression], so
+bounds can be checked at compile-time for constant arrays with a constant index
+value. Otherwise a check will be performed at run-time that will put the thread
+in a _panicked state_ if it fails.
 
 ```rust,should_panic
 ([1, 2, 3, 4])[2];        // Evaluates to 3
@@ -69,6 +68,8 @@ arr[10];                  // panics
 The array index expression can be implemented for types other than arrays and slices
 by implementing the [Index] and [IndexMut] traits.
 
-[Index]: https://doc.rust-lang.org/std/ops/trait.Index.html
-[IndexMut]: https://doc.rust-lang.org/std/ops/trait.IndexMut.html
 [_Expression_]: expressions.html
+[place]: expressions.html#place-expressions-and-value-expressions
+[Index]: ../std/ops/trait.Index.html
+[IndexMut]: ../std/ops/trait.IndexMut.html
+[constant expression]: expressions.html#constant-expressions

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -9,13 +9,13 @@
 > &nbsp;&nbsp; `}`  
 
 A _block expression_ is similar to a module in terms of the declarations that
-are possible, but can also contain [statements](statements.html) and end with
-an expression. Each block conceptually introduces a new namespace scope. Use
+are possible, but can also contain [statements] and end with
+an [expression]. Each block conceptually introduces a new namespace scope. Use
 items can bring new names into scopes and declared items are in scope for only
 the block itself.
 
 A block will execute each statement sequentially, and then execute the
-expression (if given). If the block doesn't end in an expression, its value is
+expression, if given. If the block doesn't end in an expression, its value is
 `()`:
 
 ```rust
@@ -30,9 +30,9 @@ let x: i32 = { println!("Hello."); 5 };
 assert_eq!(5, x);
 ```
 
-Blocks are always [rvalues](expressions.html#lvalues-and-rvalues) and evaluate the last
-expression in rvalue context. This can be used to force moving a value
-if really needed.
+Blocks are always [value expressions] and evaluate the last expression in 
+value expression context. This can be used to force moving a value if really
+needed.
 
 ## `unsafe` blocks
 
@@ -60,3 +60,6 @@ let a = unsafe { f() };
 [_InnerAttribute_]: attributes.html
 [_Statement_]: statements.html
 [_Expression_]: expressions.html
+[expression]: expressions.html
+[statements]: statements.html
+[value expressions]: expressions.html#place-expressions-and-value-expressions

--- a/src/expressions/field-expr.md
+++ b/src/expressions/field-expr.md
@@ -5,11 +5,10 @@
 > &nbsp;&nbsp; [_Expression_] `.` [IDENTIFIER]
 
 A _field expression_ consists of an expression followed by a single dot and an
-[identifier](identifiers.html), when not immediately followed by a
-parenthesized expression-list (the latter is always a [method call
-expression](expressions/method-call-expr.html)). A field expression denotes a field of a
-[struct](types.html#struct-types) or [union](items/unions.html). To call a
-function stored in a struct parentheses are needed around the field expression
+[identifier], when not immediately followed by a parenthesized expression-list
+(the latter is always a [method call expression]). A field expression denotes a
+field of a [struct] or [union]. To call a function stored in a struct,
+parentheses are needed around the field expression.
 
 ```rust,ignore
 mystruct.myfield;
@@ -19,9 +18,8 @@ mystruct.method();          // Method expression
 (mystruct.function_field)() // Call expression containing a field expression
 ```
 
-A field access is an [lvalue](expressions.html#lvalues-and-rvalues) referring
-to the location of that field. When the subexpression is
-[mutable](expressions.html#mutability), the field expression is also mutable.
+A field access is a [place expression] referring to the location of that field.
+When the subexpression is [mutable], the field expression is also mutable.
 
 Also, if the type of the expression to the left of the dot is a pointer, it is
 automatically dereferenced as many times as necessary to make the field access
@@ -49,3 +47,8 @@ let d: String = x.f3;           // Move out of x.f3
 
 [_Expression_]: expressions.html
 [IDENTIFIER]: identifiers.html
+[method call expression]: expressions/method-call-expr.html
+[struct]: items/structs.html
+[union]: items/unions.html
+[place expression]: expressions.html#place-expressions-and-value-expressions
+[mutable]: expressions.html#mutability

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -18,7 +18,8 @@ the pattern are assigned to local variables in the arm's block, and control
 enters the block.
 
 When the head expression is a [place expression], the match does not allocate a
-temporary location; however, a by-value binding may copy or move from the place.
+temporary location; however, a by-value binding may copy or move from the 
+memory location.
 When possible, it is preferable to match on place expressions, as the lifetime
 of these matches inherits the lifetime of the place expression rather than being
 restricted to the inside of the match.

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,19 +9,19 @@ the patterns. The type of the patterns must equal the type of the head
 expression.
 
 A `match` behaves differently depending on whether or not the head expression
-is an [lvalue or an rvalue](expressions.html#lvalues-and-rvalues).
-If the head expression is an rvalue, it is first evaluated into a temporary
-location, and the resulting value is sequentially compared to the patterns in
-the arms until a match is found. The first arm with a matching pattern is
-chosen as the branch target of the `match`, any variables bound by the pattern
-are assigned to local variables in the arm's block, and control enters the
-block.
+is a [place expression or value expression][place expression].
+If the head expression is a [value expression], it is first evaluated into a
+temporary location, and the resulting value is sequentially compared to the
+patterns in the arms until a match is found. The first arm with a matching
+pattern is chosen as the branch target of the `match`, any variables bound by
+the pattern are assigned to local variables in the arm's block, and control
+enters the block.
 
-When the head expression is an lvalue, the match does not allocate a temporary
-location (however, a by-value binding may copy or move from the lvalue). When
-possible, it is preferable to match on lvalues, as the lifetime of these
-matches inherits the lifetime of the lvalue, rather than being restricted to
-the inside of the match.
+When the head expression is a [place expression], the match does not allocate a
+temporary location; however, a by-value binding may copy or move from the place.
+When possible, it is preferable to match on place expressions, as the lifetime
+of these matches inherits the lifetime of the place expression rather than being
+restricted to the inside of the match.
 
 An example of a `match` expression:
 
@@ -126,3 +126,5 @@ let message = match maybe_digit {
 };
 ```
 
+[place expression]: expressions.html#place-expressions-and-value-expressions
+[value expression]: expressions.html#place-expressions-and-value-expressions

--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -1,7 +1,7 @@
 # Method-call expressions
 
 A _method call_ consists of an expression followed by a single dot, an
-[identifier](identifiers.html), and a parenthesized expression-list. Method
+[identifier], and a parenthesized expression-list. Method
 calls are resolved to methods on specific traits, either statically dispatching
 to a method if the exact `self`-type of the left-hand-side is known, or
 dynamically dispatching if the left-hand-side expression is an indirect [trait
@@ -50,3 +50,5 @@ generic methods or traits are considered the same), then it is a compiler
 error. These cases require a [more specific
 syntax.](expressions/call-expr.html#disambiguating-function-calls) for method
 and function invocation.
+
+[IDENTIFIER]: identifiers.html

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -40,14 +40,13 @@ assert_eq!(y, 20);
 
 The `&` (shared borrow) and `&mut` (mutable borrow) operators are unary prefix
 operators. When applied to a [place expression], this expressions produces a
-reference (pointer) to the location that the value refers to. The place is also
-placed into a borrowed state for the duration of the reference. For a shared
-borrow (`&`), this implies that the place may not be mutated, but it may be read
-or shared again. For a mutable borrow (`&mut`), the place may not be accessed in
-any way until the borrow expires. `&mut` evaluates its operand in a mutable
-place expression context. If the `&` or `&mut` operators are applied to a [value
-expression], then a temporary value is created; the lifetime of this temporary
-value is defined by [syntactic rules].
+reference (pointer) to the location that the value refers to. The memory
+location is also placed into a borrowed state for the duration of the reference.
+For a shared borrow (`&`), this implies that the place may not be mutated, but
+it may be read or shared again. For a mutable borrow (`&mut`), the place may not
+be accessed in any way until the borrow expires. `&mut` evaluates its operand in
+a mutable place expression context. If the `&` or `&mut` operators are applied
+to a [value expression], then a [temporary value] is created.
 
 These operators cannot be overloaded.
 
@@ -70,8 +69,8 @@ The `*` (dereference) operator is also a unary prefix operator. When applied to
 a [pointer](types.html#pointer-types) it denotes the pointed-to location. If
 the expression is of type `&mut T` and `*mut T`, and is either a local
 variable, a (nested) field of a local variance or is a mutable [place 
-expression], then the resulting place can be assigned to. Dereferencing a raw
-pointer requires `unsafe`.
+expression], then the resulting memory location can be assigned to.
+Dereferencing a raw pointer requires `unsafe`.
 
 On non-pointer types `*x` is equivalent to `*std::ops::Deref::deref(&x)` in an
 [immutable place expression context](expressions.html#mutability) and
@@ -336,7 +335,7 @@ assert_eq!(x, 14);
 
 [place expression]: expressions.html#place-expressions-and-value-expressions
 [value expression]: expressions.html#place-expressions-and-value-expressions
-[syntactic rules]: expressions.html#temporary-lifetimes
+[temporary value]: expressions.html#temporary-lifetimes
 [float-int]: https://github.com/rust-lang/rust/issues/10184
 [float-float]: https://github.com/rust-lang/rust/issues/15536
 [`unit` type]: types.html#tuple-types

--- a/src/expressions/path-expr.md
+++ b/src/expressions/path-expr.md
@@ -1,10 +1,9 @@
 # Path expressions
 
-A [path](paths.html) used as an expression context denotes either a local
+A [path] used as an expression context denotes either a local
 variable or an item. Path expressions that resolve to local or static variables
-are [lvalues](expressions.html#lvalues-and-rvalues), other paths
-are rvalues. Using a `static mut` variable requires an [`unsafe`
-block](expressions/block-expr.html#unsafe-blocks).
+are [place expressions], other paths are [value expressions]. Using a
+[`static mut`] variable requires an [`unsafe` block].
 
 ```rust
 # mod globals {
@@ -19,3 +18,9 @@ let some_constructor = Some::<i32>;
 let push_integer = Vec::<i32>::push;
 let slice_reverse = <[i32]>::reverse;
 ```
+
+[place expressions]: expressions.html#place-expressions-and-value-expressions
+[value expressions]: expressions.html#place-expressions-and-value-expressions
+[path]: paths.html
+[`static mut`]: items/static-items.html#mutable-statics
+[`unsafe` block]: expressions/block-expr.html#unsafe-blocks

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -1,10 +1,10 @@
 # Struct expressions
 
 There are several forms of struct expressions. A _struct expression_ consists
-of the [path](paths.html) of a [struct item](items/structs.html), followed by a
+of the [path] of a [struct item](items/structs.html), followed by a
 brace-enclosed list of zero or more comma-separated name-value pairs, providing
 the field values of a new instance of the struct. A field name can be any
-[identifier](identifiers.html), and is separated from its value expression by a
+[identifier], and is separated from its value expression by a
 colon. In the case of a tuple struct the field names are numbers corresponding
 to the position of the field. The numbers must be written in decimal,
 containing no underscores and with no leading zeros or integer suffix. A value
@@ -14,11 +14,6 @@ except that it must specify exactly one field.
 Struct expressions can't be used directly in the head of a [loop] 
 or an [if], [if let] or [match] expression. But struct expressions can still be
 in used inside parentheses, for example.
-
-[loop]: expressions/loop-expr.html
-[if]: expressions/if-expr.html#if-expressions
-[if let]: expressions/if-expr.html#if-let-expressions
-[match]: expressions/match-expr.html
 
 A _tuple struct expression_ consists of the path of a struct item, followed by
 a parenthesized list of one or more comma-separated expressions (in other
@@ -78,3 +73,10 @@ Example:
 Point3d { x: x, y: y_value, z: z };
 Point3d { x, y: y_value, z };
 ```
+
+[IDENTIFIER]: identifiers.html
+[path]: paths.html
+[loop]: expressions/loop-expr.html
+[if]: expressions/if-expr.html#if-expressions
+[if let]: expressions/if-expr.html#if-let-expressions
+[match]: expressions/match-expr.html

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -56,8 +56,8 @@ For example, `2 + (3 * 4)` is an expression that returns the value 14.
 ### Initialized
 
 A variable is initialized if it has been assigned a value and hasn't since been
-moved from. All other lvalues are assumed to be initialized. Only unsafe Rust
-can create such an lvalue without initializing it.
+moved from. All other memory locations are assumed to be initialized. Only
+unsafe Rust can create such a memory without initializing it.
 
 ### Nominal Types
 


### PR DESCRIPTION
This effort is already underway in the compiler as well, and this is the only other place we talk about these two kinds of expressions.

I also moved a lot of links down to the bottom of the page. I already painstakingly checked that every link was correct.