### PR TITLE
Move associated items to their own page.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -34,6 +34,7 @@
         - [Traits](items/traits.md)
         - [Implementations](items/implementations.md)
         - [External blocks](items/external-blocks.md)
+    - [Associated Items](items/associated-items.md)
     - [Visibility and Privacy](visibility-and-privacy.md)
     - [Attributes](attributes.md)
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -15,7 +15,7 @@ associating item. For example, the `is_some` method on `Option` is intrinsically
 related to Options, so should be associated.
 
 Every associated item kind comes in two varieties: definitions that contain the
-actual implementation and declarations that declare specifications for
+actual implementation and declarations that declare signatures for
 definitions.
 
 It is the declarations that make up the contract of traits and what it available
@@ -25,20 +25,18 @@ on generic types.
 
 *Associated functions* are [functions] associated with a type.
 
-An *associated function declaration* declares a specification for an associated
+An *associated function declaration* declares a signature for an associated
 function definition. It is written as a function item, except the
-function block is replaced with a `;`.
+function body is replaced with a `;`.
 
-The identifier if the name of the function. The generics declares types for
-usage in the rest of the function declaration. The generics, parameter list,
-return type, and where clause must be the same in the associated function
-definition.
+The identifier if the name of the function. The generics, parameter list,
+return type, and where clause of the associated function must be the same as the
+associated function declarations's.
 
-An *associated function definiton* is written as an associated function
-declaration, but instead of a `;`, there is a [block] that evaluates to the
-return type.
+An *associated function definiton* defines a function associated with another
+type. It is written the same as a [function item].
 
-An example of a common associated function is the `new` function that returns
+An example of a common associated function is a `new` function that returns
 a value of the type the associated function is associated with.
 
 ```rust
@@ -53,21 +51,30 @@ impl Struct {
         }
     }
 }
+
+fn main () {
+    let _struct = Struct::new();
+}
 ```
 
 When the associated function is declared on a trait, the function can also be
-called on the trait. When this happens, it is substituted for
-`<_ as Trait>::function_name`.
+called with a [path] that is a path to the trait appended by the name of the
+trait. When this happens, it is substituted for `<_ as Trait>::function_name`.
 
 ```rust
 trait Num {
     fn from_i32(n: i32) -> Self;
 }
+
 impl Num for f64 {
     fn from_i32(n: i32) -> f64 { n as f64 }
 }
-let x: f64 = Num::from_i32(42);
-let x: f64 = f64::from_i32(42);
+
+// These 4 are all equivalent in this case.
+let _: f64 = Num::from_i32(42);
+let _: f64 = <_ as Num>::from_i32(42);
+let _: f64 = <f64 as Num>::from_i32(42);
+let _: f64 = f64::from_i32(42);
 ```
 
 Associated functions whose first parameter is named `self` are called *methods*
@@ -78,7 +85,7 @@ When the first parameter is named `self`, the following shorthands may be used.
 
 * `self` -> `self: Self`
 * `&'lifetime self` -> `self: &'lifetime Self`
-* `&'lifetime mut self` -> `&'lifetime mut Self`
+* `&'lifetime mut self` -> `self: &'lifetime mut Self`
 
 > Note: Lifetimes can be and usually are elided with this shorthand.
 
@@ -129,9 +136,9 @@ let bounding_box = circle_shape.bounding_box();
 types cannot be defined in [inherent implementations] nor can they be given a
 default implementation in traits.
 
-An *associated type declaration* declares a specification for associated type
+An *associated type declaration* declares a signature for associated type
 definitions. It is written as `type`, then an [identifier], and
-finally an optional trait bounds.
+finally an optional list of trait bounds.
 
 The identifier is the name of the declared type alias. The optional trait bounds
 must be fulfilled by the implementations of the type alias.
@@ -139,10 +146,10 @@ must be fulfilled by the implementations of the type alias.
 An *associated type definition* defines a type alias on another type. It is 
 written as `type`, then an [identifier], then an `=`, and finally a [type].
 
-If an item `Item` has an associated type `Assoc` from a trait `Trait`, then 
+If a type `Item` has an associated type `Assoc` from a trait `Trait`, then 
 `<Item as Trait>::Assoc` is a type that is an alias of the type specified in the
-associated type definition. Furthermore, `Item::Assoc` can be used in type
-parameters.
+associated type definition. Furthermore, if `Item` is a type parameter, then 
+`Item::Assoc` can be used in type parameters.
 
 ```rust
 trait AssociatedType {
@@ -205,14 +212,14 @@ impl<T> Container for Vec<T> {
 
 *Associated constants* are [constants] associated with a type.
 
-An *associated constant declaration* declares a specificatoin for associated
+An *associated constant declaration* declares a signature for associated
 constant definitions. It is written as `const`, then an identifier,
 then `:`, then a type, finished by a `;`.
 
 The identifier is the name of the constant used in the path. The type is the
 type that the definition has to implement.
 
-An *associated constant definition* defines a constant associated with another
+An *associated constant definition* defines a constant associated with a
 type. It is written the same as a [constant item].
 
 ### Associated Constants Examples
@@ -270,3 +277,4 @@ fn main() {
 [functions]: items/functions.html
 [method call operator]: expressions/method-call-expr.html
 [block]: expressions/block-expr.html
+[path]: paths.html

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -1,0 +1,260 @@
+# Associated Items
+
+*Associated Items* are the items declared in [traits] or defined in
+[implementations]. They are called this because they are defined on an associate
+type &mdash; the type in the implementation. They are a subset of the kinds of
+items you can declare in a module. Specifically, there are [associated
+functions], [associated types], and [associated constants].
+
+[associated functions]: #associated-functions-and-methods
+[associated types]: #associated-types
+[associated constants]: #associated-constants
+
+Associated items are useful when the associated item logically is related to the
+associating item. For example, the `is_some` method on `Option` is intrinsically
+related to Options, so should be associated.
+
+Associated items are also the contract that traits have. 
+
+## Associated functions and methods
+
+*Associated functions* are [functions] associated with a type.
+
+An *associated function declaration* is written as `fn`, then an [identifier]
+then optional generics, then `(` then a parameter list, then `)`, then
+optionally `->` and a type, then an optional where clause, then finally a `;`.
+
+The identifier if the name of the function. The generics declares types for
+usage in the rest of the function declaration. The generics, parameter list,
+return type, and where clause must be the same in the associated function
+definition.
+
+An *associated function definiton* is written as an associated function
+declaration, but instead of a `;`, there is a [block] that evaluates to the
+return type.
+
+An example of a common associated function is the `new` function that returns
+a value of the type the associated function is associated with.
+
+```rust
+struct Struct {
+    field: i32;
+}
+
+impl Struct {
+    fn new() -> Struct {
+        Struct {
+            field: 0i32
+        }
+    }
+}
+```
+
+When the associated function is declared on a trait, the function can be called
+on the trait. When this happens, it is substituted for
+`<_ as Trait>::function_name`. 
+
+```rust
+trait Num {
+    fn from_i32(n: i32) -> Self;
+}
+impl Num for f64 {
+    fn from_i32(n: i32) -> f64 { n as f64 }
+}
+let x: f64 = Num::from_i32(42);
+let x: f64 = f64::from_i32(42);
+```
+
+Associated functions whose first parameter is named `self` are called *methods*
+and may be invoked using the [method call operator], for example, `x.foo()`, as
+well as the usual function call notation.
+
+When the first parameter is named `self`, the following shorthands may be used:
+
+* `self` -> `self: Self`
+* `&self` -> `self: &Self`
+* `&mut self` -> `&mut Self`
+* `Box<self>` -> `self: Box<Self>`
+
+Consider the following trait:
+
+```rust
+# type Surface = i32;
+# type BoundingBox = i32;
+trait Shape {
+    fn draw(&self, Surface);
+    fn bounding_box(&self) -> BoundingBox;
+}
+```
+
+This defines a trait with two methods. All values that have [implementations]
+of this trait in scope can have their `draw` and `bounding_box` methods called.
+
+```rust
+# type Surface = i32;
+# type BoundingBox = i32;
+# trait Shape {
+#     fn draw(&self, Surface);
+#     fn bounding_box(&self) -> BoundingBox;
+# }
+
+struct Circle {
+    // ...
+}
+
+impl Shape for Circle {
+    // ...
+#   fn draw(&self, Surface) -> {}
+#   fn bounding_box(&self) -> BoundingBox { 0i32; }
+}
+
+# impl Box {
+#     fn new() -> Circle { Circle{} }
+}
+
+let circle_shape = Circle::new();
+let bounding_box = circle_shape.bounding_box();
+```
+
+## Associated Types
+
+*Associated types* are [type aliases] associated with another type. Associated
+types cannot be defined in [inherent implementations] nor can they be given a
+default implementation in traits.
+
+An *associated type declaration* is written as `type`, then an [identifier], and
+finally an optional trait bounds.
+
+The identifier is the name of the declared type alias. The optional trait bounds
+must be fulfilled by the implementations of the type alias.
+
+An *associated type definition* is written as `type`, then an [identifier], then
+an `=`, and finally a [type].
+
+If an item `Item` has an associated type `Assoc`, then `Item::Assoc` is a type
+that is an alias of the type specified in the associated type definition.
+
+```rust
+trait AssociatedType {
+    // Associated type declaration
+    type Assoc;
+}
+
+struct Struct;
+
+struct OtherStruct;
+
+impl AssociatedType for Struct {
+    // Associated type definition
+    type Assoc = OtherStruct;
+}
+
+impl OtherStruct {
+    fn new() -> OtherStruct {
+        OtherStruct
+    }
+}
+
+fn main() {
+    // Usage of the associated type to refer to OtherStruct as Struct::Assoc
+    let _other_struct: OtherStruct = Struct::Assoc::new();
+}
+```
+
+### Associated Types Container Example
+
+Consider the following example of a `Container` trait. Notice how the type is
+available for use in the method signatures:
+
+```rust
+trait Container {
+    type E;
+    fn empty() -> Self;
+    fn insert(&mut self, Self::E);
+}
+```
+
+In order for a type to implement this trait, it must not only provide
+implementations for every method, but it must specify the type `E`. Here's an
+implementation of `Container` for the standard library type `Vec`:
+
+```rust
+# trait Container {
+#     type E;
+#     fn empty() -> Self;
+#     fn insert(&mut self, Self::E);
+# }
+impl<T> Container for Vec<T> {
+    type E = T;
+    fn empty() -> Vec<T> { Vec::new() }
+    fn insert(&mut self, x: T) { self.push(x); }
+}
+```
+
+## Associated Constants
+
+*Associated constants* are [constants] associated with a type.
+
+An *associated constant declaration* is written as `const`, then an identifier,
+then `:`, then a type, finished by a `;`.
+
+The identifier is the name of the constant used in the path. The type is the
+type that the definition has to implement.
+
+An *associated constant definition* is written as a declaraction, but between
+the type and the `;`, there is an `=` followed by a [constant expression].
+
+### Associated Constants Examples
+
+A basic example:
+
+```rust
+trait ConstantId {
+    const ID: i32;
+}
+
+struct Struct;
+
+impl ConstantId for Struct {
+    const ID: i32 = 1;
+}
+
+fn main() {
+    assert_eq!(1, Struct::ID);
+}
+```
+
+Using default values:
+
+```rust
+trait ConstantIdDefault {
+    const ID: i32 = 1;
+}
+
+struct Struct;
+struct OtherStruct;
+
+impl ConstantIdDefault for Struct {}
+
+impl ConstantIdDefault for OtherStruct {
+    const ID: i32 = 5;
+}
+
+fn main() {
+    assert_eq!(1, Struct::ID);
+    assert_eq!(5, OtherStruct::ID);
+}
+```
+
+[trait]: items/traits.html
+[type aliases]: items/type-aliases.html
+[inherent implementations]: items/implementations.html#inherent-implementations
+[identifier]: identifiers.html
+[trait object]: types.html#trait-objects
+[implementations]: items/implementations.html
+[type]: types.html
+[constants]: items/constants.html
+[constant expression]: expressions.html#constant-expressions
+[functions]: items/functions.html
+[method call operator]: expressions/method-call-expr.html
+[block]: expressions/block-expr.html

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -12,10 +12,10 @@ on completion.
 [type]: types.html
 
 When referred to, a _function_ yields a first-class *value* of the
-corresponding zero-sized [*function item type*][function item type], which
+corresponding zero-sized [*function item type*], which
 when called evaluates to a direct call to the function.
 
-[function item type]: types.html#function-item-types
+[*function item type*]: types.html#function-item-types
 
 For example, this is a simple function:
 ```rust

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -1,11 +1,11 @@
 # Traits
 
 A _trait_ describes an abstract interface that types can implement. This
-interface consists of associated items, which come in three varieties:
+interface consists of [associated items], which come in three varieties:
 
-- [functions](#associated-functions-and-methods)
-- [types](#associated-types)
-- [constants](#associated-constants)
+- [functions](items/associated-items.html#associated-functions-and-methods)
+- [types](items/associated-items.html#associated-types)
+- [constants](items/associated-items.html#associated-constants)
 
 All traits define an implicit type parameter `Self` that refers to "the type
 that is implementing this interface". Traits may also contain additional type
@@ -13,178 +13,6 @@ parameters. These type parameters (including `Self`) may be constrained by
 other traits and so forth as usual.
 
 Traits are implemented for specific types through separate [implementations].
-
-## Associated functions and methods
-
-Associated functions whose first parameter is named `self` are called methods
-and may be invoked using `.` notation (e.g., `x.foo()`) as well as the usual
-function call notation (`foo(x)`).
-
-Consider the following trait:
-
-```rust
-# type Surface = i32;
-# type BoundingBox = i32;
-trait Shape {
-    fn draw(&self, Surface);
-    fn bounding_box(&self) -> BoundingBox;
-}
-```
-
-This defines a trait with two methods. All values that have [implementations]
-of this trait in scope can have their `draw` and `bounding_box` methods called,
-using `value.bounding_box()` [syntax]. Note that `&self` is short for `self:
-&Self`, and similarly, `self` is short for `self: Self` and  `&mut self` is
-short for `self: &mut Self`.
-
-[trait object]: types.html#trait-objects
-[implementations]: items/implementations.html
-[syntax]: expressions/method-call-expr.html
-
-Traits can include default implementations of methods, as in:
-
-```rust
-trait Foo {
-    fn bar(&self);
-    fn baz(&self) { println!("We called baz."); }
-}
-```
-
-Here the `baz` method has a default implementation, so types that implement
-`Foo` need only implement `bar`. It is also possible for implementing types to
-override a method that has a default implementation.
-
-Type parameters can be specified for a trait to make it generic. These appear
-after the trait name, using the same syntax used in [generic
-functions](items/functions.html#generic-functions).
-
-```rust
-trait Seq<T> {
-    fn len(&self) -> u32;
-    fn elt_at(&self, n: u32) -> T;
-    fn iter<F>(&self, F) where F: Fn(T);
-}
-```
-
-Associated functions may lack a `self` argument, sometimes called 'static
-methods'. This means that they can only be called with function call syntax
-(`f(x)`) and not method call syntax (`obj.f()`). The way to refer to the name
-of a static method is to qualify it with the trait name or type name, treating
-the trait name like a module. For example:
-
-```rust
-trait Num {
-    fn from_i32(n: i32) -> Self;
-}
-impl Num for f64 {
-    fn from_i32(n: i32) -> f64 { n as f64 }
-}
-let x: f64 = Num::from_i32(42);
-let x: f64 = f64::from_i32(42);
-```
-
-## Associated Types
-
-It is also possible to define associated types for a trait. Consider the
-following example of a `Container` trait. Notice how the type is available for
-use in the method signatures:
-
-```rust
-trait Container {
-    type E;
-    fn empty() -> Self;
-    fn insert(&mut self, Self::E);
-}
-```
-
-In order for a type to implement this trait, it must not only provide
-implementations for every method, but it must specify the type `E`. Here's an
-implementation of `Container` for the standard library type `Vec`:
-
-```rust
-# trait Container {
-#     type E;
-#     fn empty() -> Self;
-#     fn insert(&mut self, Self::E);
-# }
-impl<T> Container for Vec<T> {
-    type E = T;
-    fn empty() -> Vec<T> { Vec::new() }
-    fn insert(&mut self, x: T) { self.push(x); }
-}
-```
-
-## Associated Constants
-
-A trait can define constants like this:
-
-```rust
-trait Foo {
-    const ID: i32;
-}
-
-impl Foo for i32 {
-    const ID: i32 = 1;
-}
-
-fn main() {
-    assert_eq!(1, i32::ID);
-}
-```
-
-Any implementor of `Foo` will have to define `ID`. Without the definition:
-
-```rust,compile_fail,E0046
-trait Foo {
-    const ID: i32;
-}
-
-impl Foo for i32 {
-}
-```
-
-gives
-
-```text
-error: not all trait items implemented, missing: `ID` [E0046]
-     impl Foo for i32 {
-     }
-```
-
-A default value can be implemented as well:
-
-```rust
-trait Foo {
-    const ID: i32 = 1;
-}
-
-impl Foo for i32 {
-}
-
-impl Foo for i64 {
-    const ID: i32 = 5;
-}
-
-fn main() {
-    assert_eq!(1, i32::ID);
-    assert_eq!(5, i64::ID);
-}
-```
-
-As you can see, when implementing `Foo`, you can leave it unimplemented, as
-with `i32`. It will then use the default value. But, as in `i64`, we can also
-add our own definition.
-
-Associated constants don’t have to be associated with a trait. An `impl` block
-for a `struct` or an `enum` works fine too:
-
-```rust
-struct Foo;
-
-impl Foo {
-    const FOO: u32 = 3;
-}
-```
 
 ## Trait bounds
 
@@ -212,6 +40,20 @@ fn draw_twice<T: Shape>(surface: Surface, sh: T) {
 fn draw_figure<U: Shape>(surface: Surface, Figure(sh1, sh2): Figure<U>) {
     sh1.draw(surface);
     draw_twice(surface, sh2); // Can call this since U: Shape
+}
+```
+
+## Generic Traits
+
+Type parameters can be specified for a trait to make it generic. These appear
+after the trait name, using the same syntax used in [generic
+functions](items/functions.html#generic-functions).
+
+```rust
+trait Seq<T> {
+    fn len(&self) -> u32;
+    fn elt_at(&self, n: u32) -> T;
+    fn iter<F>(&self, F) where F: Fn(T);
 }
 ```
 
@@ -302,3 +144,4 @@ let nonsense = mycircle.radius() * mycircle.area();
 [explicit]: expressions/operator-expr.html#type-cast-expressions
 [methods called]: expressions/method-call-expr.html
 [RFC 255]: https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md
+[associated items]: items/associated-items.html

--- a/src/types.md
+++ b/src/types.md
@@ -554,8 +554,8 @@ Here, `first` has type `A`, referring to `to_vec`'s `A` type parameter; and
 
 ## Self types
 
-The special type `Self` has a meaning within traits and impls: it refers to
-the implementing type. For example, in:
+The special type `Self` has a meaning within traits and implementations: it
+refers to the implementing type. For example, in:
 
 ```rust
 pub trait From<T> {
@@ -584,7 +584,7 @@ impl Printable for String {
 }
 ```
 
-The notation `&self` is a shorthand for `self: &Self`.
+> Note: The notation `&self` is a shorthand for `self: &Self`.
 
 [Fn]: ../std/ops/trait.Fn.html
 [FnMut]: ../std/ops/trait.FnMut.html


### PR DESCRIPTION
Because they are a cutting concern between impls and traits, they don't really fit in either.

If anybody has concrete suggestions for how to make this better, I'm all ears. I'm not a fan of a lot of my writing in this PR. Especially the definitions.