### PR TITLE
Clarify which types range patterns work on

### DIFF
--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -117,8 +117,7 @@ let message = match x {
 };
 ```
 
-Range patterns only work on scalar types (like integers and characters; not
-like arrays and structs, which have sub-components). A range pattern may not be
+Range patterns only work on `char` and numeric types. A range pattern may not be
 a sub-range of another range pattern inside the same `match`.
 
 Finally, match patterns can accept *pattern guards* to further refine the


### PR DESCRIPTION
According to the Rust book, the word "scalar types" means ["integers, floating-point numbers, booleans, and characters."](https://doc.rust-lang.org/book/second-edition/ch03-02-data-types.html#scalar-types)

However, range patterns don't work on booleans.
(No one would actually use range patterns on booleans, of course.)