### PR TITLE
Document RFC 1940 (must_use on fns)

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -400,7 +400,9 @@ fn main() {
 
 When used on a function, if the [expression] of an
 [expression statement] is a [call expression] to that function, then the
-`unused_must_use` lint is violated.
+`unused_must_use` lint is violated. The exceptions to this is if the return type
+of the function is `()`, `!`, or a [zero-variant enum], in which case the
+attribute does nothing.
 
 ```rust
 #[must_use]
@@ -514,3 +516,4 @@ You can implement `derive` for your own type through [procedural macros].
 [`Drop`]: special-types-and-traits.html#drop
 [let statement]: statements.html#let-statements
 [unstable book plugin]: ../unstable-book/language-features/plugin.html#lint-plugins
+[zero-variant enum]: enumerations.html#zero-variant-enums

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -414,6 +414,27 @@ fn main() {
 }
 ```
 
+When used on a function in a trait declaration, then the behavior also applies
+when the call expression is a function from an implementation of the trait.
+
+```rust
+trait Trait {
+  #[must_use]
+  fn use_me(&self) -> i32;
+}
+
+impl Trait for i32 {
+  fn use_me(&self) -> i32 { 0i32 }
+}
+
+fn main() {
+  // Violates the `unused_must_use` lint.
+  5i32.use_me();
+}
+```
+
+When used on a function in an implementation, the attribute does nothing.
+
 > Note: Trivial no-op expressions containing the value will not violate the
 > lint. Examples include wrapping the value in a type that does not implement
 > [`Drop`] and then not using that type and being the final expression of a

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -373,7 +373,7 @@ pub mod m3 {
 }
 ```
 
-#### Must Use Attribute
+#### `must_use` Attribute
 
 The `must_use` attribute can be used on user-defined composite types
 ([`struct`s][struct], [`enum`s][enum], and [`union`s][union]) and [functions].
@@ -391,7 +391,7 @@ struct MustUse {
 # impl MustUse {
 #   fn new() -> MustUse { MustUse {} }
 # }
-
+#
 fn main() {
   // Violates the `unused_must_use` lint.
   MustUse::new();

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -106,7 +106,7 @@ Closures have no layout guarantees.
 
 ## Representations
 
-All user-defined composite types (`struct`s, `enum`, and `union`s) have a
+All user-defined composite types (`struct`s, `enum`s, and `union`s) have a
 *representation* that specifies what the layout is for the type.
 
 The possible representations for a type are the default representation, `C`, the


### PR DESCRIPTION
* [Rendered](https://havvy.net/rust-reference/attributes.html)
* [Tracking Issue](https://github.com/rust-lang/rust/issues/43302)
* [RFC](http://rust-lang.github.io/rfcs/1940-must-use-functions.html)
* [Unstable Book Docs](https://doc.rust-lang.org/nightly/unstable-book/language-features/fn-must-use.html)

This is the reference side of documenting this attribute &mdash; both the updates for the RFC and the original functionality. I do not think that this PR is sufficient documentation for stabilizing the feature, as I think the API guidelines should also be updated.