### PR TITLE
Improve documentation on closure types.

### DIFF
--- a/src/types.md
+++ b/src/types.md
@@ -378,7 +378,7 @@ let mut s = String::from("foo");
 let t = String::from("bar");
 
 f(|| {
-    s += t;
+    s += &*t;
     s
 });
 // Prints "foobar".
@@ -386,15 +386,15 @@ f(|| {
 
 generates a closure type roughly like the following:
 
-```rust
+```rust,ignore
 struct Closure<'a> {
-    s : String
-    t : &'a String
+    s : String,
+    t : &'a String,
 }
 
-impl<'a> FnOnce() -> String for Closure<'a> {
+impl<'a> (FnOnce() -> String) for Closure<'a> {
     fn call_once(self) -> String {
-        self.s += self.t;
+        self.s += &*self.t;
         self.s
     }
 }
@@ -419,12 +419,14 @@ may be necessary to borrow into a local variable in order to capture a single
 field:
 
 ```rust
+# use std::collections::HashSet;
+# 
 struct SetVec {
     set: HashSet<u32>,
     vec: Vec<u32>
 }
 
-impl Pair {
+impl SetVec {
     fn populate(&mut self) {
         let vec = &mut self.vec;
         self.set.iter().for_each(|&n| {

--- a/src/types.md
+++ b/src/types.md
@@ -452,10 +452,10 @@ more specific call traits:
 * A closure which does not mutate or move out of any captured variables
   implements `[Fn]`, indicating that it can be called by shared reference.
 
-> Note that `move` closures may still implement `[Fn]` or `[FnMut]`, even
-> though they capture variables by move: this is because the traits
-> implemented by a closure type are determined by what the closure does with
-> captured values, not how it captures them.
+> Note: `move` closures may still implement `[Fn]` or `[FnMut]`, even though
+> they capture variables by move. This is because the traits implemented by a
+> closure type are determined by what the closure does with captured values, not
+> how it captures them.
 
 *Non-capturing closures* are closures that don't capture anything from their
 environment. They can be coerced to function pointers (`fn`) with the matching


### PR DESCRIPTION
This PR more fully documents closure types, including the mechanics of captures and the traits implemented by them. I intend to work on closure expressions as well, either in this PR or a follow-up, but felt this was a good place to put them.

I didn't fully explain capturing here, as I feel like that's better for closure expressions. The bit about no field captures might make more sense there as well, but I think the mechanics of how captures are typed and the implications on the traits belong here.

This PR is written for a post-[RFC 2132](https://github.com/rust-lang/rfcs/blob/master/text/2132-copy-closures.md) world, where closures have `Clone` and `Copy`, and intended as part of the stabilization docs for that RFC. The tracking issue is rust-lang/rust#44490. That bit could easily be split out though.

Fixes #219, fixes #229.