### PR TITLE
fixes #250

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -430,3 +430,4 @@ You can implement `derive` for your own type through [procedural macros].
 [Doc comments]: comments.html#doc-comments
 [The Rustdoc Book]: ../rustdoc/the-doc-attribute.html
 [procedural macros]: procedural-macros.html
+[unstable book plugin]: ../unstable-book/language-features/plugin.html#lint-plugins


### PR DESCRIPTION
`[Compiler plugins][unstable book plugin]` is now a link again. See #250