### PR TITLE
Split identifiers from keywords or identifiers

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -1,19 +1,25 @@
 # Identifiers
 
 > **<sup>Lexer:<sup>**  
-> IDENTIFIER :  
+> IDENTIFIER_OR_KEYWORD :  
 > &nbsp;&nbsp; &nbsp;&nbsp; [`a`-`z` `A`-`Z`]&nbsp;[`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>\*</sup>  
 > &nbsp;&nbsp; | `_` [`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>+</sup>  
+>  
+> IDENTIFIER :  
+> IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub>
 
 An identifier is any nonempty ASCII string of the following form:
 
 Either
 
-   * The first character is a letter
-   * The remaining characters are alphanumeric or `_`
+* The first character is a letter.
+* The remaining characters are alphanumeric or `_`.
 
 Or
 
-   * The first character is `_`
-   * The identifier is more than one character, `_` alone is not an identifier
-   * The remaining characters are alphanumeric or `_`
+* The first character is `_`.
+* The identifier is more than one character. `_` alone is not an identifier.
+* The remaining characters are alphanumeric or `_`.
+
+[strict]: keywords.html#strict-keywords
+[reserved]: keywords.html#reserved-keywords

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -26,7 +26,7 @@ syntax named by _designator_. Valid designators are:
 * `pat`: a [pattern]
 * `expr`: an [expression]
 * `ty`: a [type]
-* `ident`: an [identifier]
+* `ident`: an [identifier] or [keyword]
 * `path`: a [path]
 * `tt`: a token tree (a single [token] by matching `()`, `[]`, or `{}`)
 * `meta`: the contents of an [attribute]
@@ -38,6 +38,7 @@ syntax named by _designator_. Valid designators are:
 [expression]: expressions.html
 [type]: types.html
 [identifier]: identifiers.html
+[keyword]: keyword.html
 [path]: paths.html
 [token]: tokens.html
 [attribute]: attributes.html

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -486,10 +486,16 @@ The two values of the boolean type are written `true` and `false`.
 ## Lifetimes and loop labels
 
 > **<sup>Lexer</sup>**  
+> LIFETIME_TOKEN
+> &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER_OR_KEYWORD][identifier]  
+> &nbsp;&nbsp; | `'_`  
+>  
 > LIFETIME_OR_LABEL:  
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER][identifier]
 
-Lifetime parameters and [loop labels] both use this syntax.
+Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any
+LIFETIME_TOKEN will be accepted by the lexer, and for example, can be used in
+macros.
 
 [loop labels]: expressions/loop-expr.html
 


### PR DESCRIPTION
Separate identifiers, and keywords including identifiers in the grammar.