### PR TITLE
Color inline code links

### DIFF
--- a/src/theme/reference.css
+++ b/src/theme/reference.css
@@ -45,8 +45,19 @@ p.warning a {
     color: rgb(0, 136, 204)
 }
 
-a .hljs {
+/* color hyperlinked inline code items identically to normal links */
+.light a > .hljs {
     color: #4183c4;
+}
+
+.rust a > .hljs,
+.coal a > .hljs,
+.navy a > .hljs {
+    color: #2b79a2;
+}
+
+.ayu a > .hljs {
+    color: #0096cf;
 }
 
 /*


### PR DESCRIPTION
Color links containing inline code the same as normal links. Use the CSS found in the [Cookbook](https://github.com/rust-lang-nursery/rust-cookbook/blob/master/theme/custom.css).
cc rust-lang-nursery/mdBook#537