### PR TITLE
Moved grouped expressions to its own page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -45,6 +45,7 @@
         - [Path expressions](expressions/path-expr.md)
         - [Block expressions](expressions/block-expr.md)
         - [Operator expressions](expressions/operator-expr.md)
+        - [Grouped expressions](expressions/grouped-expr.md)
         - [Array and index expressions](expressions/array-expr.md)
         - [Tuple and index expressions](expressions/tuple-expr.md)
         - [Struct expressions](expressions/struct-expr.md)

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -247,6 +247,7 @@ Many of the following operators and expressions can also be overloaded for
 other types using traits in `std::ops` or `std::cmp`. These traits also
 exist in `core::ops` and `core::cmp` with the same names.
 
+[grouped]:              expressions/grouped-expr.html
 [block expressions]:    expressions/block-expr.html
 [call expressions]:     expressions/call-expr.html
 [closure expressions]:  expressions/closure-expr.html
@@ -272,7 +273,6 @@ exist in `core::ops` and `core::cmp` with the same names.
 [dereferences]:         expressions/operator-expr.html#the-dereference-operator
 [dereferencing]:        expressions/operator-expr.html#the-dereference-operator
 [dereference operator]: expressions/operator-expr.html#the-dereference-operator
-[grouped]:              expressions/operator-expr.html#grouped-expressions
 [lazy boolean]:         expressions/operator-expr.html#lazy-boolean-operators
 [negation]:             expressions/operator-expr.html#negation-operators
 [overflow]:             expressions/operator-expr.html#overflow

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -247,12 +247,12 @@ Many of the following operators and expressions can also be overloaded for
 other types using traits in `std::ops` or `std::cmp`. These traits also
 exist in `core::ops` and `core::cmp` with the same names.
 
-[grouped]:              expressions/grouped-expr.html
 [block expressions]:    expressions/block-expr.html
 [call expressions]:     expressions/call-expr.html
 [closure expressions]:  expressions/closure-expr.html
 [enum variant]:         expressions/enum-variant-expr.html
 [field]:                expressions/field-expr.html
+[grouped]:              expressions/grouped-expr.html
 [literals]:             expressions/literal-expr.html
 [match]:                expressions/match-expr.html
 [method-call]:          expressions/method-call-expr.html

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -8,8 +8,6 @@ An expression enclosed in parentheses evaluates to the result of the enclosed
 expression. Parentheses can be used to explicitly specify evaluation order
 within an expression.
 
-This operator cannot be overloaded.
-
 An example of a parenthesized expression:
 
 ```rust
@@ -33,8 +31,8 @@ that is a member of a struct:
 # }
 # let a = A{f: || "The field f"};
 # 
-assert_eq!(  a.f (), "The method f");
-assert_eq!( (a.f)(), "The field f");
+assert_eq!( a.f (), "The method f");
+assert_eq!((a.f)(), "The field f");
 ```
 
 [_Expression_]: expressions.html

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -1,0 +1,40 @@
+# Grouped expressions
+
+> **<sup>Syntax</sup>**  
+> _GroupedExpression_ :  
+> &nbsp;&nbsp; `(` [_Expression_] `)`
+
+An expression enclosed in parentheses evaluates to the result of the enclosed
+expression. Parentheses can be used to explicitly specify evaluation order
+within an expression.
+
+This operator cannot be overloaded.
+
+An example of a parenthesized expression:
+
+```rust
+let x: i32 = 2 + 3 * 4;
+let y: i32 = (2 + 3) * 4;
+assert_eq!(x, 14);
+assert_eq!(y, 20);
+```
+
+An example of a necessary use of parentheses is when calling a function pointer
+that is a member of a struct:
+
+```rust
+# struct A {
+#    f: fn() -> &'static str
+# }
+# impl A {
+#    fn f(&self) -> &'static str {
+#        "The method f"
+#    }
+# }
+# let a = A{f: || "The field f"};
+# 
+assert_eq!(  a.f (), "The method f");
+assert_eq!( (a.f)(), "The field f");
+```
+
+[_Expression_]: expressions.html

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -32,27 +32,6 @@ overflow:
 * Using `<<` or `>>` where the right-hand argument is greater than or equal to
   the number of bits in the type of the left-hand argument, or is negative.
 
-## Grouped expressions
-
-> **<sup>Syntax</sup>**  
-> _GroupedExpression_ :  
-> &nbsp;&nbsp; `(` [_Expression_] `)`
-
-An expression enclosed in parentheses evaluates to the result of the enclosed
-expression. Parentheses can be used to explicitly specify evaluation order
-within an expression.
-
-This operator cannot be overloaded.
-
-An example of a parenthesized expression:
-
-```rust
-let x: i32 = 2 + 3 * 4;
-let y: i32 = (2 + 3) * 4;
-assert_eq!(x, 14);
-assert_eq!(y, 20);
-```
-
 ## Borrow operators
 
 > **<sup>Syntax</sup>**  


### PR DESCRIPTION
and added another example of its use.

Should I remove this bit ```This operator cannot be overloaded.```? It is not really an operator.