### PR TITLE
Added the grammar for inclusive ranges

### DIFF
--- a/src/expressions/range-expr.md
+++ b/src/expressions/range-expr.md
@@ -6,6 +6,8 @@
 > &nbsp;&nbsp; | _RangeFromExpr_  
 > &nbsp;&nbsp; | _RangeToExpr_  
 > &nbsp;&nbsp; | _RangeFullExpr_  
+> &nbsp;&nbsp; | _RangeInclusiveExpr_  
+> &nbsp;&nbsp; | _RangeToInclusiveExpr_  
 >  
 > _RangeExpr_ :  
 > &nbsp;&nbsp; [_Expression_] `..` [_Expression_]  
@@ -18,6 +20,12 @@
 >  
 > _RangeFullExpr_ :  
 > &nbsp;&nbsp; `..`  
+>  
+> _RangeInclusiveExpr_ :  
+> &nbsp;&nbsp; [_Expression_] `..=` [_Expression_]  
+>  
+> _RangeToInclusiveExpr_ :  
+> &nbsp;&nbsp; `..=` [_Expression_]  
 
 The `..` operator will construct an object of one of the `std::ops::Range` (or
 `core::ops::Range`) variants, according to the following table:
@@ -28,14 +36,18 @@ The `..` operator will construct an object of one of the `std::ops::Range` (or
 | _RangeFromExpr_        | start`..`     | [std::ops::RangeFrom]        | start &le; x          |
 | _RangeToExpr_          | `..`end       | [std::ops::RangeTo]          |            x &lt; end |
 | _RangeFullExpr_        | `..`          | [std::ops::RangeFull]        |            -          |
+| _RangeInclusiveExpr_   | start`..=`end | [std::ops::RangeInclusive]   | start &le; x &le; end |
+| _RangeToInclusiveExpr_ | `..=`end      | [std::ops::RangeToInclusive] |            x &le; end |
 
 Examples:
 
 ```rust
-1..2;   // std::ops::Range
-3..;    // std::ops::RangeFrom
-..4;    // std::ops::RangeTo
-..;     // std::ops::RangeFull
+let a = 1..2;   // std::ops::Range
+let a = 3..;    // std::ops::RangeFrom
+let a = ..4;    // std::ops::RangeTo
+let a = ..;     // std::ops::RangeFull
+let a = 1..=2;  // std::ops::RangeInclusive
+let a = ..=10;  // std::ops::RangeToInclusive
 ```
 
 The following expressions are equivalent.
@@ -61,3 +73,6 @@ for i in 1..11 {
 [std::ops::RangeFrom]: https://doc.rust-lang.org/std/ops/struct.RangeFrom.html
 [std::ops::RangeTo]:   https://doc.rust-lang.org/std/ops/struct.RangeTo.html
 [std::ops::RangeFull]: https://doc.rust-lang.org/std/ops/struct.RangeFull.html
+[std::ops::RangeInclusive]: https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html
+[std::ops::RangeToInclusive]: https://doc.rust-lang.org/std/ops/struct.RangeToInclusive.html
+


### PR DESCRIPTION
They are not stabilized yet, but I had made this before the decision about only including stable things on the reference. So, the reviewer can put the `Waiting on Stabilization` tag on this PR.