### PR TITLE
WIP: Patterns chapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -60,6 +60,8 @@
         - [Match expressions](expressions/match-expr.md)
         - [Return expressions](expressions/return-expr.md)
 
+- [Patterns](patterns.md)
+
 - [Type system](type-system.md)
     - [Types](types.md)
     - [Dynamically Sized Types](dynamically-sized-types.md)

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -44,7 +44,7 @@ assert_eq!(y, "Bigger");
 
 > **<sup>Syntax</sup>**  
 > _IfLetExpression_ :  
-> &nbsp;&nbsp; `if` `let` _Pattern_ `=` [_Expression_]<sub>_except struct expression_</sub>
+> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Expression_]<sub>_except struct expression_</sub>
 >              [_BlockExpression_]  
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
@@ -94,3 +94,4 @@ assert_eq!(a, 3);
 
 [_Expression_]: expressions.html
 [_BlockExpression_]: expressions/block-expr.html
+[_Pattern_]: patterns.html

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -67,7 +67,7 @@ while i < 10 {
 
 > **<sup>Syntax</sup>**  
 > [_PredicatePatternLoopExpression_] :  
-> &nbsp;&nbsp; `while` `let` _Pattern_ `=` [_Expression_]<sub>except struct expression</sub>
+> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Expression_]<sub>except struct expression</sub>
 >              [_BlockExpression_]  
 
 A `while let` loop is semantically similar to a `while` loop but in place of a
@@ -213,5 +213,6 @@ expression `()`.
 
 [_Expression_]:      expressions.html
 [_BlockExpression_]: expressions/block-expr.html
+[_Pattern_]: patterns.html
 
 [LIFETIME_OR_LABEL]: tokens.html#lifetimes-and-loop-labels

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -70,14 +70,14 @@ Multiple match patterns may be joined with the `|` operator:
 # let x = 9;
 let message = match x {
     0 | 1  => "not many",
-    2 ... 9 => "a few",
+    2 ..= 9 => "a few",
     _      => "lots"
 };
 
 assert_eq!(message, "a few");
 ```
 
-Please notice that the `2...9` is a [Range Pattern], not a [Range Expression]
+Please notice that the `2..=9` is a [Range Pattern], not a [Range Expression]
 and, thus, only those types of ranges supported by range patterns can be used
 in match arms.
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -1,35 +1,32 @@
 # `match` expressions
 
-> **<sup>Syntax</sup>**
-> _MatchExpression_ :
-> &nbsp;&nbsp; `match` [_Expression_]<sub>_except struct expression_</sub> `{`
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>
-> &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>
-> &nbsp;&nbsp; `}`
->
-> _MatchArms_ :
+> **<sup>Syntax</sup>**  
+> _MatchExpression_ :  
+> &nbsp;&nbsp; `match` [_Expression_]<sub>_except struct expression_</sub> `{`  
+> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>  
+> &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>  
+> &nbsp;&nbsp; `}`  
+>  
+> _MatchArms_ :  
 > &nbsp;&nbsp; ( _MatchArm_ `=>`
 >                             ( [_BlockExpression_] `,`<sup>?</sup>
 >                             | [_Expression_] `,` )
->                           )<sup>\*</sup>
-> &nbsp;&nbsp; _MatchArm_ `=>` ( [_BlockExpression_] | [_Expression_] ) `,`<sup>?</sup>
->
-> _MatchArm_ :
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> _MatchArmPatterns_ _MatchArmGuard_<sup>?</sup>
->
-> _MatchArmPatterns_ :
-> &nbsp;&nbsp; `|`<sup>?</sup> _Pattern_ ( `|` _Pattern_ )<sup>*</sup>
->
-> _MatchArmGuard_ :
-> &nbsp;&nbsp; `if` [_Expression_]
+>                           )<sup>\*</sup>  
+> &nbsp;&nbsp; _MatchArm_ `=>` ( [_BlockExpression_] | [_Expression_] ) `,`<sup>?</sup>  
+>  
+> _MatchArm_ :  
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> _MatchArmPatterns_ _MatchArmGuard_<sup>?</sup>  
+>  
+> _MatchArmPatterns_ :  
+> &nbsp;&nbsp; `|`<sup>?</sup> [_Pattern_] ( `|` [_Pattern_] )<sup>*</sup>  
+>  
+> _MatchArmGuard_ :  
+> &nbsp;&nbsp; `if` [_Expression_]  
 
 A `match` expression branches on a *pattern*. The exact form of matching that
-occurs depends on the pattern. Patterns consist of some combination of
-literals, destructured arrays or enum constructors, structs and tuples,
-variable binding specifications, wildcards (`..`), and placeholders (`_`). A
-`match` expression has a *head expression*, which is the value to compare to
-the patterns. The type of the patterns must equal the type of the head
-expression.
+occurs depends on the pattern. See [Patterns] for more details. A `match` 
+expression has a *head expression*, which is the value to compare to the
+patterns. The type of the patterns must equal the type of the head expression.
 
 A `match` behaves differently depending on whether or not the head expression
 is a [place expression or value expression][place expression].
@@ -65,101 +62,28 @@ match x {
 Patterns that bind variables default to binding to a copy or move of the
 matched value (depending on the matched value's type). This can be changed to
 bind to a reference by using the `ref` keyword, or to a mutable reference using
-`ref mut`.
+`ref mut`. See [Identifier Patterns].
 
-Patterns can be used to *destructure* structs, enums, and tuples. Destructuring
-breaks a value up into its component pieces. The syntax used is the same as
-when creating such values. When destructing a data structure with named (but
-not numbered) fields, it is allowed to write `fieldname` as a shorthand for
-`fieldname: fieldname`. In a pattern whose head expression has a `struct`,
-`enum` or `tupl` type, a placeholder (`_`) stands for a *single* data field,
-whereas a wildcard `..` stands for *all* the fields of a particular variant.
-
-```rust
-# enum Message {
-#     Quit,
-#     WriteString(String),
-#     Move { x: i32, y: i32 },
-#     ChangeColor(u8, u8, u8),
-# }
-# let message = Message::Quit;
-match message {
-    Message::Quit => println!("Quit"),
-    Message::WriteString(write) => println!("{}", &write),
-    Message::Move{ x, y: 0 } => println!("move {} horizontally", x),
-    Message::Move{ .. } => println!("other move"),
-    Message::ChangeColor { 0: red, 1: green, 2: _ } => {
-        println!("color change, red: {}, green: {}", red, green);
-    }
-};
-```
-
-Patterns can also dereference pointers by using the `&`, `&mut` and `box`
-symbols, as appropriate. For example, these two matches on `x: &i32` are
-equivalent:
-
-```rust
-# let x = &3;
-let y = match *x { 0 => "zero", _ => "some" };
-let z = match x { &0 => "zero", _ => "some" };
-
-assert_eq!(y, z);
-```
-
-Subpatterns can also be bound to variables by the use of the syntax `variable @
-subpattern`. For example:
-
-```rust
-let x = 1;
-
-match x {
-    e @ 1 ... 5 => println!("got a range element {}", e),
-    _ => println!("anything"),
-}
-```
-
-Multiple match patterns may be joined with the `|` operator. An inclusive range
-of values may be specified with `..=`. For example:
+Multiple match patterns may be joined with the `|` operator:
 
 ```rust
 # let x = 9;
 let message = match x {
     0 | 1  => "not many",
-    2 ..= 9 => "a few",
+    2 ... 9 => "a few",
     _      => "lots"
 };
 
 assert_eq!(message, "a few");
 ```
 
-Other forms of [range] \(`..` for an exclusive range, or any range with one or
-both endpoints left unspecified) are not supported in matches. The
-syntax `...` is also accepted for inclusive ranges in patterns only, for
-backwards compatibility.
+Please notice that the `2...9` is a [Range Pattern], not a [Range Expression]
+and, thus, only those types of ranges supported by range patterns can be used
+in match arms.
 
-Range patterns only work [`char`] and [numeric types]. A range pattern may not
-be a sub-range of another range pattern inside the same `match`.
+A range pattern may not be a sub-range of another range pattern inside the same `match`.
 
-Slice patterns can match both arrays of fixed size and slices of dynamic size.
-```rust
-// Fixed size
-let arr = [1, 2, 3];
-match arr {
-    [1, _, _] => "starts with one",
-    [a, b, c] => "starts with something else",
-};
-```
-```rust
-// Dynamic size
-let v = vec![1, 2, 3];
-match v[..] {
-    [a, b] => { /* this arm will not apply because the length doesn't match */ }
-    [a, b, c] => { /* this arm will apply */ }
-    _ => { /* this wildcard is required, since we don't know length statically */ }
-}
-```
-
-Finally, match patterns can accept *pattern guards* to further refine the
+Match patterns can accept _match guards_ to further refine the
 criteria for matching a case. Pattern guards appear after the pattern and
 consist of a bool-typed expression following the `if` keyword. A pattern guard
 may refer to the variables bound within the pattern they follow.
@@ -179,8 +103,14 @@ let message = match maybe_digit {
 [_BlockExpression_]: expressions/block-expr.html#block-expressions
 [place expression]: expressions.html#place-expressions-and-value-expressions
 [value expression]: expressions.html#place-expressions-and-value-expressions
-[`char`]: types.html#textual-types
-[numeric types]: types.html#numeric-types
 [_InnerAttribute_]: attributes.html
 [_OuterAttribute_]: attributes.html
-[range]: expressions/range-expr.html
+[Range Expression]: expressions/range-expr.html
+
+[_Pattern_]: patterns.html
+[Patterns]: patterns.html
+[Identifier Patterns]: patterns.html#identifier-patterns
+[Struct Patterns]: patterns.html#struct-patterns
+[Tuple Struct Patterns]: patterns.html#tuplestruct-patterns
+[Tuple Patterns]: patterns.html#tuple-patterns
+[Range Pattern]: patterns.html#range-patterns

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -552,7 +552,7 @@ let arr = [1, 2, 3];
 match arr {
     [1, _, _] => "starts with one",
     [a, b, c] => "starts with something else",
-}
+};
 ```
 ```rust
 // Dynamic size
@@ -561,7 +561,7 @@ match v[..] {
     [a, b] => { /* this arm will not apply because the length doesn't match */ }
     [a, b, c] => { /* this arm will apply */ }
     _ => { /* this wildcard is required, since we don't know length statically */ }
-}
+};
 ```
 
 ## Path patterns

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -39,7 +39,7 @@ For example, the pattern used in:
 if let
     Person {
         car: Some(_),
-        age: person_age @ 13...19,
+        age: person_age @ 13..=19,
         name: ref person_name,
         ..
     } = person
@@ -202,7 +202,8 @@ The wildcard pattern is always irrefutable.
 
 > **<sup>Syntax</sup>**  
 > _RangePattern_ :  
-> &nbsp;&nbsp;  _RangePatternBound_ `...` _RangePatternBound_  
+> &nbsp;&nbsp;&nbsp;&nbsp;  _RangePatternBound_ `..=` _RangePatternBound_  
+> &nbsp;&nbsp; | _RangePatternBound_ `...` _RangePatternBound_  
 >  
 > _RangePatternBound_ :  
 > &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]  
@@ -216,11 +217,13 @@ The wildcard pattern is always irrefutable.
 [_QualifiedPathInExpression_]: paths.html
 
 Range patterns match values that are within the closed range defined by its lower and
-upper bounds. For example, a pattern `'m'...'p'` will match only the values `'m'`, `'n'`,
+upper bounds. For example, a pattern `'m'..='p'` will match only the values `'m'`, `'n'`,
 `'o'`, and `'p'`. The bounds can be literals or paths that point to constant values.
 
-A pattern a `...` b must always have a &le; b. Thus, it is not possible to have a range
-pattern `10...0`, for example.
+A pattern a `..=` b must always have a &le; b. Thus, it is not possible to have a range
+pattern `10..=0`, for example.
+
+The `...` syntax is kept for backwards compatibility.
 
 Range patterns only work on scalar types. The accepted types are:
 
@@ -235,17 +238,17 @@ Examples:
 ```rust
 # let c = 'f';
 let valid_variable = match c {
-    'a'...'z' => true,
-    'A'...'Z' => true,
-    'α'...'ω' => true,
+    'a'..='z' => true,
+    'A'..='Z' => true,
+    'α'..='ω' => true,
     _ => false,
 };
 
 # let ph = 10;
 println!("{}", match ph {
-    0...6 => "acid",
+    0..=6 => "acid",
     7 => "neutral",
-    8...14 => "base",
+    8..=14 => "base",
     _ => unreachable!(),
 });
 
@@ -262,9 +265,9 @@ println!("{}", match ph {
 # let altitude = 70;
 # 
 println!("{}", match altitude {
-    TROPOSPHERE_MIN...TROPOSPHERE_MAX => "troposphere",
-    STRATOSPHERE_MIN...STRATOSPHERE_MAX => "stratosphere",
-    MESOSPHERE_MIN...MESOSPHERE_MAX => "mesosphere",
+    TROPOSPHERE_MIN..=TROPOSPHERE_MAX => "troposphere",
+    STRATOSPHERE_MIN..=STRATOSPHERE_MAX => "stratosphere",
+    MESOSPHERE_MIN..=MESOSPHERE_MAX => "mesosphere",
     _ => "outer space, maybe",
 });
 
@@ -274,7 +277,7 @@ println!("{}", match altitude {
 # }
 # let n_items = 20_832_425;
 # let bytes_per_item = 12;
-if let size @ binary::MEGA...binary::GIGA = n_items * bytes_per_item {
+if let size @ binary::MEGA..=binary::GIGA = n_items * bytes_per_item {
     println!("It fits and occupies {} bytes", size);
 }
 
@@ -292,16 +295,16 @@ if let size @ binary::MEGA...binary::GIGA = n_items * bytes_per_item {
 # }
 // using qualified paths:
 println!("{}", match 0xfacade {
-    0 ... <u8 as MaxValue>::MAX => "fits in a u8",
-    0 ... <u16 as MaxValue>::MAX => "fits in a u16",
-    0 ... <u32 as MaxValue>::MAX => "fits in a u32",
+    0 ..= <u8 as MaxValue>::MAX => "fits in a u8",
+    0 ..= <u16 as MaxValue>::MAX => "fits in a u16",
+    0 ..= <u32 as MaxValue>::MAX => "fits in a u32",
     _ => "too big",
 });
 
 ```
 
 Range patterns are always refutable, even when they cover the complete set
-of possible values of a type. For example, `0u8...255u8` is refutable even though
+of possible values of a type. For example, `0u8..=255u8` is refutable even though
 it covers all possible values of `u8`.
 
 ## Reference patterns
@@ -357,7 +360,7 @@ subpattern` is needed. For example:
 let x = 2;
 
 match x {
-    e @ 1 ... 5 => println!("got a range element {}", e),
+    e @ 1 ..= 5 => println!("got a range element {}", e),
     _ => println!("anything"),
 }
 ```
@@ -393,7 +396,7 @@ the value's fields. For example:
 #    age: u8,
 # }
 # let value = Person{ name: String::from("John"), age: 23 };
-if let Person{& name: person_name, age: 18...150} = value { }
+if let Person{& name: person_name, age: 18..=150} = value { }
 ```
 
 is not valid. What we must do is:
@@ -404,7 +407,7 @@ is not valid. What we must do is:
 #    age: u8,
 # }
 # let value = Person{ name: String::from("John"), age: 23 };
-if let Person{name: ref person_name, age: 18...150} = value { }
+if let Person{name: ref person_name, age: 18..=150} = value { }
 ```
 
 Thus, `ref` is not something that is being matched against. Its objective is

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -1,0 +1,601 @@
+# Patterns
+
+> **<sup>Syntax</sup>**  
+> _Pattern_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; [_LiteralPattern_]  
+> &nbsp;&nbsp; | [_WildcardPattern_]  
+> &nbsp;&nbsp; | [_RangePattern_]  
+> &nbsp;&nbsp; | [_ReferencePattern_]  
+> &nbsp;&nbsp; | [_IdentifierPattern_]  
+> &nbsp;&nbsp; | [_StructPattern_]  
+> &nbsp;&nbsp; | [_TupleStructPattern_]  
+> &nbsp;&nbsp; | [_TuplePattern_]  
+> &nbsp;&nbsp; | [_SlicePattern_]  
+> &nbsp;&nbsp; | [_PathPattern_]  
+
+Patterns in Rust are used to match values against structures and to,
+optionally, bind variables to values inside these structures. They are also
+used in variable declarations and function/closure parameters, though in these
+cases most of the time they are simply used as an identifier that binds to a
+value.
+
+For example, the pattern used in:
+
+```rust
+# struct Car;
+# struct Computer;
+# struct Person {
+#     name: String,
+#     car: Option<Car>,
+#     computer: Option<Computer>,
+#     age: u8,
+# }
+# let person = Person {
+#     name: String::from("John"),
+#     car: Some(Car),
+#     computer: None,
+#     age: 15,
+# };
+if let
+    Person {
+        car: Some(_),
+        age: person_age @ 13...19,
+        name: ref person_name,
+        ..
+    } = person
+{
+    println!("{} has a car and is {} years old.", person_name, person_age);
+}
+```
+does four things:
+
+* Tests if `person` has the `car` field filled with something.
+* Tests if the person's `age` field is between 13 and 19, and binds its value to
+  the `person_age` variable.
+* Binds a reference to the `name` field to the variable `person_name`.
+* Ignores the rest of the fields of `person`, i.e., they can have any value and
+  are not bound to any variables.
+
+Patterns are used in:
+
+* [`let` declarations](statements.html#let-statements)
+* [Function](items.html#functions) and [closure](expressions.html#closure-expressions)
+  parameters
+* [`match` expressions](expressions.html#match-expressions)
+* [`if let` expressions](expressions.html#if-let-expressions)
+* [`while let` expressions](expressions.html#while-let-loops)
+* Inside other patterns
+
+## Destructuring
+
+Patterns can be used to *destructure* structs, enums, and tuples. Destructuring
+breaks a value up into its component pieces. The syntax used is almost the same as
+when creating such values. When destructing a data structure with named (but
+not numbered) fields, it is allowed to write `fieldname` as a shorthand for
+`fieldname: fieldname`. In a pattern whose head expression has a `struct`,
+`enum` or `tupl` type, a placeholder (`_`) stands for a *single* data field,
+whereas a wildcard `..` stands for *all* the remaining fields of a particular variant.
+
+```rust
+# enum Message {
+#     Quit,
+#     WriteString(String),
+#     Move { x: i32, y: i32 },
+#     ChangeColor(u8, u8, u8),
+# }
+# let message = Message::Quit;
+match message {
+    Message::Quit => println!("Quit"),
+    Message::WriteString(write) => println!("{}", &write),
+    Message::Move{ x, y: 0 } => println!("move {} horizontally", x),
+    Message::Move{ .. } => println!("other move"),
+    Message::ChangeColor { 0: red, 1: green, 2: _ } => {
+        println!("color change, red: {}, green: {}", red, green);
+    }
+};
+```
+
+## Refutability
+
+A pattern is said to be *Refutable* when it **has the possibily of not being matched**
+by the value it is being matched against. *Irrefutable* patterns, on the other hand,
+always match the value they are being matched against. Examples:
+
+```rust
+let (x, y) = (1, 2);               // "(x, y)" is an irrefutable pattern
+
+if let (a, 3) = (1, 2) {           // "(a, 3)" is refutable, and will not match
+    panic!("Shouldn't reach here");
+} else if let (a, 4) = (3, 4) {    // "(a, 4)" is refutable, and will match
+    println!("Matched ({}, 4)", a);
+}
+```
+
+## Literal patterns
+
+> **<sup>Syntax</sup>**  
+> _LiteralPattern_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; [BOOLEAN_LITERAL]  
+> &nbsp;&nbsp; | [CHAR_LITERAL]  
+> &nbsp;&nbsp; | [BYTE_LITERAL]  
+> &nbsp;&nbsp; | [STRING_LITERAL]  
+> &nbsp;&nbsp; | [RAW_STRING_LITERAL]  
+> &nbsp;&nbsp; | [BYTE_STRING_LITERAL]  
+> &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]  
+> &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]  
+> &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]  
+
+[BOOLEAN_LITERAL]: tokens.html#boolean-literals
+[CHAR_LITERAL]: tokens.html#character-literals
+[BYTE_LITERAL]: tokens.html#byte-literals
+[STRING_LITERAL]: tokens.html#string-literals
+[RAW_STRING_LITERAL]: tokens.html#raw-string-literals
+[BYTE_STRING_LITERAL]: tokens.html#byte-string-literals
+[RAW_BYTE_STRING_LITERAL]: tokens.html#raw-byte-string-literals
+[INTEGER_LITERAL]: tokens.html#integer-literals
+[FLOAT_LITERAL]: tokens.html#floating-point-literals
+
+_Literal patterns_ match exactly the value they represent. Since negative numbers are
+not literals in Rust, literal patterns also accept an optional minus sign before the
+literal.
+
+Floating-point literals are currently accepted, but due to the complexity of comparing
+them, they are going to be forbidden on literal patterns in a future version of Rust (see
+[issue #41620](https://github.com/rust-lang/rust/issues/41620)).
+
+Literal patterns are always refutable.
+
+Examples:
+
+```rust
+for i in -2..5 {
+    match i {
+        -1 => println!("It's minus one"),
+        1 => println!("It's a one"),
+        2|4 => println!("It's either a two or a four"),
+        _ => println!("Matched none of the arms"),
+    }
+}
+```
+
+## Wildcard pattern
+
+> **<sup>Syntax</sup>**  
+> _WildcardPattern_ :  
+> &nbsp;&nbsp; `_`
+
+The _wildcard pattern_ matches any value. It is used to ignore values when they don't
+matter. Inside other patterns it matches a single data field (as opposed to the `..`
+which matches the remaining fields).
+
+Examples: 
+
+```rust
+# let x = 20;
+let (a, _) = (10, x);   // the x is always matched by _
+# assert_eq!(a, 10);
+
+// ignore a function/closure param
+let real_part = |a: f64, _: f64| { a };
+
+// ignore a field from a struct
+# struct RGBA {
+#    r: f32,
+#    g: f32,
+#    b: f32,
+#    a: f32,
+# }
+# let color = RGBA{r: 0.4, g: 0.1, b: 0.9, a: 0.5};
+let RGBA{r: red, g: green, b: blue, a: _} = color;
+# assert_eq!(color.r, red);
+# assert_eq!(color.g, green);
+# assert_eq!(color.b, blue);
+
+// accept any Some, with any value
+# let x = Some(10);
+if let Some(_) = x {}
+```
+
+The wildcard pattern is always irrefutable.
+
+## Range patterns
+
+> **<sup>Syntax</sup>**  
+> _RangePattern_ :  
+> &nbsp;&nbsp;  _RangePatternBound_ `...` _RangePatternBound_  
+>  
+> _RangePatternBound_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]  
+> &nbsp;&nbsp; | [BYTE_LITERAL]  
+> &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]  
+> &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]  
+> &nbsp;&nbsp; | [_PathInExpression_]  
+> &nbsp;&nbsp; | [_QualifiedPathInExpression_]  
+
+[_PathInExpression_]: paths.html
+[_QualifiedPathInExpression_]: paths.html
+
+Range patterns match values that are within the closed range defined by its lower and
+upper bounds. For example, a pattern `'m'...'p'` will match only the values `'m'`, `'n'`,
+`'o'`, and `'p'`. The bounds can be literals or paths that point to constant values.
+
+A pattern a `...` b must always have a &le; b. Thus, it is not possible to have a range
+pattern `10...0`, for example.
+
+Range patterns only work on scalar types. The accepted types are:
+
+* Integer types (u8, i8, u16, i16, usize, isize, etc.).
+* Character types (char).
+* Floating point types (f32 and f64). This is being deprecated and will not be available
+  in a future version of Rust (see
+  [issue #41620](https://github.com/rust-lang/rust/issues/41620)).
+
+Examples:
+
+```rust
+# let c = 'f';
+let valid_variable = match c {
+    'a'...'z' => true,
+    'A'...'Z' => true,
+    'α'...'ω' => true,
+    _ => false,
+};
+
+# let ph = 10;
+println!("{}", match ph {
+    0...6 => "acid",
+    7 => "neutral",
+    8...14 => "base",
+    _ => unreachable!(),
+});
+
+// using paths to constants:
+# const TROPOSPHERE_MIN : u8 = 6;
+# const TROPOSPHERE_MAX : u8 = 20;
+# 
+# const STRATOSPHERE_MIN : u8 = TROPOSPHERE_MAX + 1;
+# const STRATOSPHERE_MAX : u8 = 50;
+# 
+# const MESOSPHERE_MIN : u8 = STRATOSPHERE_MAX + 1;
+# const MESOSPHERE_MAX : u8 = 85;
+# 
+# let altitude = 70;
+# 
+println!("{}", match altitude {
+    TROPOSPHERE_MIN...TROPOSPHERE_MAX => "troposphere",
+    STRATOSPHERE_MIN...STRATOSPHERE_MAX => "stratosphere",
+    MESOSPHERE_MIN...MESOSPHERE_MAX => "mesosphere",
+    _ => "outer space, maybe",
+});
+
+# pub mod binary {
+#     pub const MEGA : u64 = 1024*1024;
+#     pub const GIGA : u64 = 1024*1024*1024;
+# }
+# let n_items = 20_832_425;
+# let bytes_per_item = 12;
+if let size @ binary::MEGA...binary::GIGA = n_items * bytes_per_item {
+    println!("It fits and occupies {} bytes", size);
+}
+
+# trait MaxValue {
+#     const MAX: u64;
+# }
+# impl MaxValue for u8 {
+#     const MAX: u64 = (1 << 8) - 1;
+# }
+# impl MaxValue for u16 {
+#     const MAX: u64 = (1 << 16) - 1;
+# }
+# impl MaxValue for u32 {
+#     const MAX: u64 = (1 << 32) - 1;
+# }
+// using qualified paths:
+println!("{}", match 0xfacade {
+    0 ... <u8 as MaxValue>::MAX => "fits in a u8",
+    0 ... <u16 as MaxValue>::MAX => "fits in a u16",
+    0 ... <u32 as MaxValue>::MAX => "fits in a u32",
+    _ => "too big",
+});
+
+```
+
+Range patterns are always refutable, even when they cover the complete set
+of possible values of a type. For example, `0u8...255u8` is refutable even though
+it covers all possible values of `u8`.
+
+## Reference patterns
+
+> **<sup>Syntax</sup>**  
+> _ReferencePattern_ :  
+> &nbsp;&nbsp; (`&`|`&&`) `mut`<sup>?</sup> _Pattern_  
+
+Reference patterns dereference the pointers that are being matched
+and, thus, borrow them.
+
+For example, these two matches on `x: &i32` are equivalent:
+
+```rust
+# let x = &3;
+let y = match *x { 0 => "zero", _ => "some" };
+let z = match x { &0 => "zero", _ => "some" };
+
+assert_eq!(y, z);
+```
+
+The grammar production for reference patterns has to match the token `&&`
+because it is a token by itself, not two `&` tokens.
+
+Reference patterns are always irrefutable.
+
+## Identifier patterns
+
+> **<sup>Syntax</sup>**  
+> _IdentifierPattern_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; `mut`<sup>?</sup> IDENTIFIER (`@` [_Pattern_] ) <sup>?</sup>  
+> &nbsp;&nbsp; | `ref` `mut`<sup>?</sup> IDENTIFIER (`@` [_Pattern_] ) <sup>?</sup>
+
+_Identifier patterns_ bind the value they match to a **previously undeclared** variable.
+
+Patterns that consist of only an identifier, possibly with a `mut`, like
+`variable`, `x`, and `y` below:
+
+```rust
+let mut variable = 10;
+fn sum(x: i32, y: i32) -> i32 {
+#    x + y
+# }
+```
+
+match any value and bind it to that identifier. This is the most commonly
+used pattern in variable declarations and function/closure parameters.
+
+To bind non-trivial patterns to a variable, the use of the syntax `variable @
+subpattern` is needed. For example:
+
+```rust
+let x = 2;
+
+match x {
+    e @ 1 ... 5 => println!("got a range element {}", e),
+    _ => println!("anything"),
+}
+```
+
+binds to `e` the value 2 (not the entire range: the range here is a range subpattern).
+
+By default, identifier patterns bind a variable to a copy of or move from the
+matched value (depending whether the matched value implements the [Copy trait]).
+This can be changed to bind to a reference by using the `ref` keyword,
+or to a mutable reference using `ref mut`. For example:
+
+```rust
+# let a = Some(10);
+match a {
+    None => (),
+    Some(value) => (),
+}
+
+match a {
+    None => (),
+    Some(ref value) => (),
+}
+```
+
+in the first match expression, the value is copied (or moved). In the second match,
+a reference to the same memory location is bound to the variable value. This syntax is
+needed because in destructuring subpatterns we can't apply the `&` operator to
+the value's fields. For example:
+
+```rust,compile_fail
+# struct Person {
+#    name: String,
+#    age: u8,
+# }
+# let value = Person{ name: String::from("John"), age: 23 };
+if let Person{& name: person_name, age: 18...150} = value { }
+```
+
+is not valid. What we must do is:
+
+```rust
+# struct Person {
+#    name: String,
+#    age: u8,
+# }
+# let value = Person{ name: String::from("John"), age: 23 };
+if let Person{name: ref person_name, age: 18...150} = value { }
+```
+
+Thus, `ref` is not something that is being matched against. Its objective is
+exclusively to make the matched binding a reference, instead of potentially
+copying or moving what was matched.
+
+## Struct patterns
+
+> **<sup>Syntax</sup>**  
+> _StructPattern_ :  
+> &nbsp;&nbsp; _Path_ `{`  
+> &nbsp;&nbsp; &nbsp;&nbsp; _StructPatternElements_ <sup>?</sup>  
+> &nbsp;&nbsp; `}`  
+>  
+> _StructPatternElements_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; _StructPatternFields_ (`,` | `,` _StructPatternEtCetera_)<sup>?</sup>  
+> &nbsp;&nbsp; | _StructPatternEtCetera_  
+>  
+> _StructPatternFields_ :  
+> &nbsp;&nbsp; _StructPatternField_ (`,` _StructPatternField_) <sup>\*</sup>  
+>  
+> _StructPatternField_ :  
+> &nbsp;&nbsp; _OuterAttribute_ <sup>\*</sup>  
+> &nbsp;&nbsp; (  
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; INTEGER_LITERAL `:` [_Pattern_]  
+> &nbsp;&nbsp; &nbsp;&nbsp; | IDENTIFIER `:` [_Pattern_]  
+> &nbsp;&nbsp; &nbsp;&nbsp; | `ref`<sup>?</sup> `mut`<sup>?</sup> IDENTIFIER  
+> &nbsp;&nbsp; )  
+>  
+> _StructPatternEtCetera_ :  
+> &nbsp;&nbsp; _OuterAttribute_ <sup>\*</sup>  
+> &nbsp;&nbsp; `..`  
+
+Struct patterns match struct values that match all criteria defined by its subpatterns.
+They are also used to [destructure](destructuring) a struct.
+
+On a struct pattern, the fields are referenced by name, index (in the case of tuples
+structs) or ignored by use of `..`:
+
+```rust
+# struct Point {
+#     x: u32,
+#     y: u32,
+# }
+# let s = Point {x: 1, y: 1};
+# 
+match s {
+    Point {x: 10, y: 20} => (),
+    Point {y: 10, x: 20} => (),    // order doesn't matter
+    Point {x: 10, ..} => (),
+    Point {..} => (),
+}
+
+# struct PointTuple (
+#     u32,
+#     u32,
+# );
+# let t = PointTuple(1, 2);
+# 
+match t {
+    PointTuple {0: 10, 1: 20} => (),
+    PointTuple {1: 10, 0: 20} => (),   // order doesn't matter
+    PointTuple {0: 10, ..} => (),
+    PointTuple {..} => (),
+}
+```
+
+If `..` is not used, it is required to match all fields:
+
+```rust
+# struct Struct {
+#    a: i32,
+#    b: char,
+#    c: bool,
+# }
+# let mut struct_value = Struct{a: 10, b: 'X', c: false};
+# 
+match struct_value {
+    Struct{a: 10, b: 'X', c: false} => (),
+    Struct{a: 10, b: 'X', ref c} => (),
+    Struct{a: 10, b: 'X', ref mut c} => (),
+    Struct{a: 10, b: 'X', c: _} => (),
+    Struct{a: _, b: _, c: _} => (),
+}
+```
+
+The `ref` and/or `mut` _IDENTIFIER_ syntax matches any value and binds it to
+a variable with the same name as the given field. 
+
+```rust
+# struct Struct {
+#    a: i32,
+#    b: char,
+#    c: bool,
+# }
+# let struct_value = Struct{a: 10, b: 'X', c: false};
+# 
+let Struct{a: x, b: y, c: z} = struct_value;          // destructure all fields
+```
+
+A struct pattern is refutable when one of its subpatterns is refutable.
+
+## TupleStruct patterns
+
+> **<sup>Syntax</sup>**  
+> _TupleStructPattern_ :  
+> &nbsp;&nbsp; _Path_ `(` _TupleStructItems_ `)`  
+>  
+> _TupleStructItems_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_]&nbsp;( `,` [_Pattern_] )<sup>\*</sup> `,`<sup>?</sup>  
+> &nbsp;&nbsp; | ([_Pattern_] `,`)<sup>\*</sup> `..` ( (`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup> )<sup>?</sup>  
+
+TupleStruct patterns match tuple struct and enum values that match all criteria defined
+by its subpatterns. They are also used to [destructure](destructuring) a tuple struct or
+enum value.
+
+A TupleStruct pattern is refutable when one of its subpatterns is refutable.
+
+## Tuple patterns
+
+> **<sup>Syntax</sup>**  
+> _TuplePattern_ :<a name="tuple-pattern-syntax"></a>  
+> &nbsp;&nbsp; `(` _TupplePatternItems_<sup>?</sup> `)`  
+>  
+> _TuplePatternItems_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_] `,`  
+> &nbsp;&nbsp; | [_Pattern_]&nbsp;(`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup>  
+> &nbsp;&nbsp; | ([_Pattern_] `,`)<sup>\*</sup> `..` ( (`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup> )<sup>?</sup>  
+
+Tuple patterns match tuple values that match all criteria defined by its subpatterns.
+They are also used to [destructure](destructuring) a tuple.
+
+This pattern is refutable when one of its subpatterns is refutable.
+
+## Slice patterns
+
+> **<sup>Syntax</sup>**  
+> _SlicePattern_ :  
+> &nbsp;&nbsp; `[` [_Pattern_] \(`,` [_Pattern_])<sup>\*</sup> `,`<sup>?</sup> `]`
+
+Slice patterns can match both arrays of fixed size and slices of dynamic size.
+```rust
+// Fixed size
+let arr = [1, 2, 3];
+match arr {
+    [1, _, _] => "starts with one",
+    [a, b, c] => "starts with something else",
+}
+```
+```rust
+// Dynamic size
+let v = vec![1, 2, 3];
+match v[..] {
+    [a, b] => { /* this arm will not apply because the length doesn't match */ }
+    [a, b, c] => { /* this arm will apply */ }
+    _ => { /* this wildcard is required, since we don't know length statically */ }
+}
+```
+
+## Path patterns
+
+> **<sup>Syntax</sup>**  
+> _PathPattern_ :  
+> &nbsp;&nbsp; &nbsp;&nbsp; _PathForExpression_  
+> &nbsp;&nbsp; | _QualifiedPathForExpression_
+
+_Path patterns_ are patterns that refer either to constant values or
+to structs or enum variants that have no fields.
+
+Unqualified path patterns can refer to:
+
+* enum variants
+* structs
+* constants
+* associated constants
+
+Qualified path patterns can only refer to associated constants.
+
+Path patterns are irrefutable when they refer to constants or structs.
+They are refutable when the refer to enum variants.
+
+[_Pattern_]: #patterns
+[_LiteralPattern_]: #literal-patterns
+[_WildcardPattern_]: #wildcard-pattern
+[_RangePattern_]: #range-patterns
+[_ReferencePattern_]: #reference-patterns
+[_IdentifierPattern_]: #identifier-patterns
+[_TupleStructPattern_]: #tuplestruct-patterns
+[_StructPattern_]: #struct-patterns
+[_TuplePattern_]: #tuple-patterns
+[_SlicePattern_]: #slice-patterns
+[_PathPattern_]: #path-patterns
+
+[Copy trait]: special-types-and-traits.html#copy


### PR DESCRIPTION
- Added the chapter about patterns, with some explanations and the grammar.
- Some sections are lacking good explanations and examples.
- Moved some documentation about patterns from the `match` expression section.
- <del>Removed the bit about the new syntax of inclusive pattern ranges (a..=b),
since it is not stable nor in the process of being stabilized.</del>
- Kept the slice patterns, since it is being stabilized.

Closes #83, closes #300, #301.