### PR TITLE
Fix grammar for orphan check

### DIFF
--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -113,9 +113,9 @@ the following conditions:
 
    ```ignore
     T = C
-      | &T
-      | &mut T
-      | Box<T>
+      | &C
+      | &mut C
+      | Box<C>
    ```
 
 ## Generic Implementations


### PR DESCRIPTION
You should double check, but I think this was wrong. It seemed odd to me.