### PR TITLE
Correct when closures are Sync.

### DIFF
--- a/src/types.md
+++ b/src/types.md
@@ -495,8 +495,7 @@ of cloning of the captured variables is left unspecified.
 
 Because captures are often by reference, the following general rules arise:
 
-* A closure is [`Sync`] if all variables captured by mutable reference, copy,
-  or move are [`Sync`].
+* A closure is [`Sync`] if all captured variables are [`Sync`].
 * A closure is [`Send`] if all variables captured by shared reference are
   [`Sync`], and all values captured by mutable reference, copy, or move are
   [`Send`].


### PR DESCRIPTION
When I wrote this, for some reason I thought that references are always
Sync.