### PR TITLE
Fix the definition of MetaItem and MetaSeq

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -15,12 +15,12 @@
 > &nbsp;&nbsp; | IDENTIFIER `=` LITERAL  
 > &nbsp;&nbsp; | IDENTIFIER `(` LITERAL `)`  
 > &nbsp;&nbsp; | IDENTIFIER `(` _MetaSeq_ `)`  
-> &nbsp;&nbsp; | IDENTIFIER `(` _MetaSeq_ `,` `)`  
+> &nbsp;&nbsp; | IDENTIFIER `(` _MetaItem_ `,` _MetaSeq_ `)`  
 >   
 > _MetaSeq_ :  
 > &nbsp;&nbsp; &nbsp;&nbsp; EMPTY  
 > &nbsp;&nbsp; | _MetaItem_  
-> &nbsp;&nbsp; | _MetaSeq_ `,` _MetaItem_  
+> &nbsp;&nbsp; | _MetaItem_ `,` _MetaSeq_
 
 Any item declaration may have an _attribute_ applied to it. Attributes in Rust
 are modeled on Attributes in ECMA-335, with the syntax coming from ECMA-334

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -15,7 +15,6 @@
 > &nbsp;&nbsp; | IDENTIFIER `=` LITERAL  
 > &nbsp;&nbsp; | IDENTIFIER `(` LITERAL `)`  
 > &nbsp;&nbsp; | IDENTIFIER `(` _MetaSeq_ `)`  
-> &nbsp;&nbsp; | IDENTIFIER `(` _MetaItem_ `,` _MetaSeq_ `)`  
 >   
 > _MetaSeq_ :  
 > &nbsp;&nbsp; &nbsp;&nbsp; EMPTY  


### PR DESCRIPTION
The current definitions mean that the following are valid attributes:

- `#[foo(,)]`
- `#[foo(, , , , ,)]`

These aren't (intended to be) valid. This fixes the definitions to only allow an EMPTY at the end of a comma-separated list.