### PR TITLE
Document underscore lifetime elision

### DIFF
--- a/src/lifetime-elision.md
+++ b/src/lifetime-elision.md
@@ -5,13 +5,13 @@ compiler can infer a sensible default choice.
 
 ## Lifetime elision in functions
 
-In order to make common patterns more ergonomic, Rust allows lifetime argument
-to be *elided* in [function item], [function pointer] and [closure trait]
-signatures. The following rules are used to infer lifetime parameters for
-elided lifetimes. It is an error to elide lifetime parameters that cannot be
-inferred. The placeholder lifetime, `'_`, can also be used to have a lifetime
-inferred in the same way. For lifetimes in paths, using `'_` is preferred.
-Trait object lifetimes follow different rules discussed
+In order to make common patterns more ergonomic, lifetime arguments can be
+*elided* in [function item], [function pointer] and [closure trait] signatures.
+The following rules are used to infer lifetime parameters for elided lifetimes.
+It is an error to elide lifetime parameters that cannot be inferred. The
+placeholder lifetime, `'_`, can also be used to have a lifetime inferred in the
+same way. For lifetimes in paths, using `'_` is preferred. Trait object
+lifetimes follow different rules discussed
 [below](#default-trait-object-lifetimes).
 
 * Each elided lifetime in the parameters becomes a distinct lifetime parameter.

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -19,6 +19,7 @@
 > _Lifetime_ :  
 > &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]  
 > &nbsp;&nbsp; | `'static`  
+> &nbsp;&nbsp; | `'_`  
 
 [Trait] and lifetime bounds provide a way for [generic items][generic] to
 restrict which types and lifetimes are used as their parameters. Bounds can be


### PR DESCRIPTION
cc #278 There don't seem to be any cases where `'_` could be used outside of this chapter.

`'_` can also be used for inferred lifetimes, but I don't think there is any documentation for them yet.

Also uses dyn trait in the elision chapter (cc #279)
