### PR TITLE
Remove 'main' attr from reference. Still unstable.

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -96,8 +96,6 @@ type int8_t = i8;
 
 ## Function-only attributes
 
-- `main` - indicates that this function should be passed to the entry point,
-  rather than the function in the crate root named `main`.
 - `test` - indicates that this function is a test function, to only be compiled
   in case of `--test`.
   - `ignore` - indicates that this test function is disabled.


### PR DESCRIPTION
This should be easy to review.