### PR TITLE
Update array expressions

### DIFF
--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -37,32 +37,37 @@ greater than 1 then this requires that the type of `a` is
 > &nbsp;&nbsp; [_Expression_] `[` [_Expression_] `]`
 
 [Array and slice](types.html#array-and-slice-types)-typed expressions can be
-indexed by writing a square-bracket-enclosed expression (the index) after them.
-When the array is mutable, the resulting [memory location] can be assigned to.
-For other types an index expression `a[b]` is equivalent to
-`*std::ops::Index::index(&a, b)`, or `*std::opsIndexMut::index_mut(&mut a, b)`
-in a mutable place expression context. Just as with methods, Rust will also
-insert dereference operations on `a` repeatedly to find an implementation.
+indexed by writing a square-bracket-enclosed expression of type `usize` (the
+index) after them. When the array is mutable, the resulting [memory location]
+can be assigned to.
 
-Indices are zero-based, and are of type `usize` for arrays and slices. Array
-access is a [constant expression], so
-bounds can be checked at compile-time for constant arrays with a constant index
+For other types an index expression `a[b]` is equivalent to
+`*std::ops::Index::index(&a, b)`, or
+`*std::ops::IndexMut::index_mut(&mut a, b)` in a mutable place expression
+context. Just as with methods, Rust will also insert dereference operations on
+`a` repeatedly to find an implementation.
+
+Indices are zero-based for arrays and slices. Array access is a [constant
+expression], so bounds can be checked at compile-time with a constant index
 value. Otherwise a check will be performed at run-time that will put the thread
 in a _panicked state_ if it fails.
 
 ```rust,should_panic
+// lint is deny by default.
+#![warn(const_err)]
+
 ([1, 2, 3, 4])[2];        // Evaluates to 3
 
 let b = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
 b[1][2];                  // multidimensional array indexing
 
-let x = (["a", "b"])[10]; // warning: const index-expr is out of bounds
+let x = (["a", "b"])[10]; // warning: index out of bounds
 
 let n = 10;
 let y = (["a", "b"])[n];  // panics
 
 let arr = ["a", "b"];
-arr[10];                  // panics
+arr[10];                  // warning: index out of bounds
 ```
 
 The array index expression can be implemented for types other than arrays and slices


### PR DESCRIPTION
* const_err is now deny-by-default (not sure how this didn't get noticed by Rust's CI)
* Indexes are checked on non-const arrays.
* Fix some typos