### PR TITLE
Use backslash instead of whitespace for hard breaks.

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -1,24 +1,24 @@
 # Attributes
 
-> **<sup>Syntax</sup>**  
-> _Attribute_ :  
-> &nbsp;&nbsp; _InnerAttribute_ | _OuterAttribute_  
->  
-> _InnerAttribute_ :  
-> &nbsp;&nbsp; `#![` MetaItem `]`  
->   
-> _OuterAttribute_ :  
-> &nbsp;&nbsp; `#[` MetaItem `]`  
->   
-> _MetaItem_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; IDENTIFIER  
-> &nbsp;&nbsp; | IDENTIFIER `=` LITERAL  
-> &nbsp;&nbsp; | IDENTIFIER `(` LITERAL `)`  
-> &nbsp;&nbsp; | IDENTIFIER `(` _MetaSeq_ `)`  
->   
-> _MetaSeq_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; EMPTY  
-> &nbsp;&nbsp; | _MetaItem_  
+> **<sup>Syntax</sup>**\
+> _Attribute_ :\
+> &nbsp;&nbsp; _InnerAttribute_ | _OuterAttribute_
+>
+> _InnerAttribute_ :\
+> &nbsp;&nbsp; `#![` MetaItem `]`
+>
+> _OuterAttribute_ :\
+> &nbsp;&nbsp; `#[` MetaItem `]`
+>
+> _MetaItem_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; IDENTIFIER\
+> &nbsp;&nbsp; | IDENTIFIER `=` LITERAL\
+> &nbsp;&nbsp; | IDENTIFIER `(` LITERAL `)`\
+> &nbsp;&nbsp; | IDENTIFIER `(` _MetaSeq_ `)`
+>
+> _MetaSeq_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; EMPTY\
+> &nbsp;&nbsp; | _MetaItem_\
 > &nbsp;&nbsp; | _MetaItem_ `,` _MetaSeq_
 
 Any [item declaration] or [generic lifetime or type parameter][generics] may
@@ -116,7 +116,7 @@ On an `extern` block, the following attributes are interpreted:
   declarations in this block to be linked correctly. `link` supports an optional
   `kind` key with three possible values: `dylib`, `static`, and `framework`. See
   [external blocks](items/external-blocks.html) for more about external blocks.
-  Two examples: `#[link(name = "readline")]` and 
+  Two examples: `#[link(name = "readline")]` and
   `#[link(name = "CoreFoundation", kind = "framework")]`.
 - `linked_from` - indicates what native library this block of FFI items is
   coming from. This attribute is of the form `#[linked_from = "foo"]` where
@@ -450,7 +450,7 @@ When used on a function in an implementation, the attribute does nothing.
 >   { five() };
 >   if true { five() } else { 0i32 };
 >   match true {
->     _ => five()  
+>     _ => five()
 >   };
 > }
 > ```

--- a/src/comments.md
+++ b/src/comments.md
@@ -1,36 +1,36 @@
 # Comments
 
-> **<sup>Lexer</sup>**  
-> LINE_COMMENT :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~[`/` `!`] | `//`) ~`\n`<sup>\*</sup>  
+> **<sup>Lexer</sup>**\
+> LINE_COMMENT :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~[`/` `!`] | `//`) ~`\n`<sup>\*</sup>\
 > &nbsp;&nbsp; | `//`
->  
-> BLOCK_COMMENT :  
+>
+> BLOCK_COMMENT :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `/*` (~[`*` `!`] | `**` | _BlockCommentOrDoc_)
->      (_BlockCommentOrDoc_ | ~`*/`)<sup>\*</sup> `*/`  
-> &nbsp;&nbsp; | `/**/`  
-> &nbsp;&nbsp; | `/***/`  
->  
-> INNER_LINE_DOC :  
-> &nbsp;&nbsp; `//!` ~[`\n` _IsolatedCR_]<sup>\*</sup>  
->  
-> INNER_BLOCK_DOC :  
-> &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_] )<sup>\*</sup> `*/`  
->  
-> OUTER_LINE_DOC :  
-> &nbsp;&nbsp; `///` (~`/` ~[`\n` _IsolatedCR_]<sup>\*</sup>)<sup>?</sup>  
->  
-> OUTER_BLOCK_DOC :  
+>      (_BlockCommentOrDoc_ | ~`*/`)<sup>\*</sup> `*/`\
+> &nbsp;&nbsp; | `/**/`\
+> &nbsp;&nbsp; | `/***/`
+>
+> INNER_LINE_DOC :\
+> &nbsp;&nbsp; `//!` ~[`\n` _IsolatedCR_]<sup>\*</sup>
+>
+> INNER_BLOCK_DOC :\
+> &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_] )<sup>\*</sup> `*/`
+>
+> OUTER_LINE_DOC :\
+> &nbsp;&nbsp; `///` (~`/` ~[`\n` _IsolatedCR_]<sup>\*</sup>)<sup>?</sup>
+>
+> OUTER_BLOCK_DOC :\
 > &nbsp;&nbsp; `/**` (~`*` | _BlockCommentOrDoc_ )
->              (_BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_])<sup>\*</sup> `*/`  
->  
-> _BlockCommentOrDoc_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; BLOCK_COMMENT  
-> &nbsp;&nbsp; | OUTER_BLOCK_DOC  
-> &nbsp;&nbsp; | INNER_BLOCK_DOC  
->  
-> _IsolatedCR_ :  
-> &nbsp;&nbsp; _A `\r` not followed by a `\n`_  
+>              (_BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_])<sup>\*</sup> `*/`
+>
+> _BlockCommentOrDoc_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; BLOCK_COMMENT\
+> &nbsp;&nbsp; | OUTER_BLOCK_DOC\
+> &nbsp;&nbsp; | INNER_BLOCK_DOC
+>
+> _IsolatedCR_ :\
+> &nbsp;&nbsp; _A `\r` not followed by a `\n`_
 
 ## Non-doc comments
 
@@ -94,16 +94,16 @@ pub mod outer_module {
     pub mod degenerate_cases {
         // empty inner line doc
         //!
-    
+
         // empty inner block doc
         /*!*/
 
         // empty line comment
         //
-        
+
         // empty outer line doc
         ///
-        
+
         // empty block comment
         /**/
 

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -1,14 +1,14 @@
 # Crates and source files
 
-> **<sup>Syntax</sup>**  
-> _Crate_ :  
-> &nbsp;&nbsp; UTF8BOM<sup>?</sup>  
-> &nbsp;&nbsp; SHEBANG<sup>?</sup>  
-> &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>  
-> &nbsp;&nbsp; [_Item_]<sup>\*</sup>  
+> **<sup>Syntax</sup>**\
+> _Crate_ :\
+> &nbsp;&nbsp; UTF8BOM<sup>?</sup>\
+> &nbsp;&nbsp; SHEBANG<sup>?</sup>\
+> &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
+> &nbsp;&nbsp; [_Item_]<sup>\*</sup>
 
-> **<sup>Lexer</sup>**  
-> UTF8BOM : `\uFEFF`  
+> **<sup>Lexer</sup>**\
+> UTF8BOM : `\uFEFF`\
 > SHEBANG : `#!` ~[`[` `\n`] ~`\n`<sup>*</sup>
 
 

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -1,30 +1,30 @@
 # Expressions
 
-> **<sup>Syntax</sup>**  
-> _Expression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_LiteralExpression_]  
-> &nbsp;&nbsp; | [_PathExpression_]  
-> &nbsp;&nbsp; | [_BlockExpression_]  
-> &nbsp;&nbsp; | [_OperatorExpression_]  
-> &nbsp;&nbsp; | [_GroupedExpression_]  
-> &nbsp;&nbsp; | [_ArrayExpression_]  
-> &nbsp;&nbsp; | [_IndexExpression_]  
-> &nbsp;&nbsp; | [_TupleExpression_]  
-> &nbsp;&nbsp; | [_TupleIndexingExpression_]  
-> &nbsp;&nbsp; | [_StructExpression_]  
-> &nbsp;&nbsp; | [_EnumerationVariantExpression_]  
-> &nbsp;&nbsp; | [_CallExpression_]  
-> &nbsp;&nbsp; | [_MethodCallExpression_]  
-> &nbsp;&nbsp; | [_FieldExpression_]  
-> &nbsp;&nbsp; | [_ClosureExpression_]  
-> &nbsp;&nbsp; | [_LoopExpression_]  
-> &nbsp;&nbsp; | [_ContinueExpression_]  
-> &nbsp;&nbsp; | [_BreakExpression_]  
-> &nbsp;&nbsp; | [_RangeExpression_]  
-> &nbsp;&nbsp; | [_IfExpression_]  
-> &nbsp;&nbsp; | [_IfLetExpression_]  
-> &nbsp;&nbsp; | [_MatchExpression_]  
-> &nbsp;&nbsp; | [_ReturnExpression_]  
+> **<sup>Syntax</sup>**\
+> _Expression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_LiteralExpression_]\
+> &nbsp;&nbsp; | [_PathExpression_]\
+> &nbsp;&nbsp; | [_BlockExpression_]\
+> &nbsp;&nbsp; | [_OperatorExpression_]\
+> &nbsp;&nbsp; | [_GroupedExpression_]\
+> &nbsp;&nbsp; | [_ArrayExpression_]\
+> &nbsp;&nbsp; | [_IndexExpression_]\
+> &nbsp;&nbsp; | [_TupleExpression_]\
+> &nbsp;&nbsp; | [_TupleIndexingExpression_]\
+> &nbsp;&nbsp; | [_StructExpression_]\
+> &nbsp;&nbsp; | [_EnumerationVariantExpression_]\
+> &nbsp;&nbsp; | [_CallExpression_]\
+> &nbsp;&nbsp; | [_MethodCallExpression_]\
+> &nbsp;&nbsp; | [_FieldExpression_]\
+> &nbsp;&nbsp; | [_ClosureExpression_]\
+> &nbsp;&nbsp; | [_LoopExpression_]\
+> &nbsp;&nbsp; | [_ContinueExpression_]\
+> &nbsp;&nbsp; | [_BreakExpression_]\
+> &nbsp;&nbsp; | [_RangeExpression_]\
+> &nbsp;&nbsp; | [_IfExpression_]\
+> &nbsp;&nbsp; | [_IfLetExpression_]\
+> &nbsp;&nbsp; | [_MatchExpression_]\
+> &nbsp;&nbsp; | [_ReturnExpression_]
 
 An expression may have two roles: it always produces a *value*, and it may have
 *effects* (otherwise known as "side effects"). An expression *evaluates to* a

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -2,11 +2,11 @@
 
 ## Array expressions
 
-> **<sup>Syntax</sup>**  
-> _ArrayExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `[`  `]`  
-> &nbsp;&nbsp; | `[` [_Expression_] ( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup> `]`  
-> &nbsp;&nbsp; | `[` [_Expression_] `;` [_Expression_] `]`  
+> **<sup>Syntax</sup>**\
+> _ArrayExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `[`  `]`\
+> &nbsp;&nbsp; | `[` [_Expression_] ( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup> `]`\
+> &nbsp;&nbsp; | `[` [_Expression_] `;` [_Expression_] `]`
 
 An _[array](types.html#array-and-slice-types) expression_ can be written by
 enclosing zero or more comma-separated expressions of uniform type in square
@@ -32,8 +32,8 @@ greater than 1 then this requires that the type of `a` is
 
 ## Array and slice indexing expressions
 
-> **<sup>Syntax</sup>**  
-> _IndexExpression_ :  
+> **<sup>Syntax</sup>**\
+> _IndexExpression_ :\
 > &nbsp;&nbsp; [_Expression_] `[` [_Expression_] `]`
 
 [Array and slice](types.html#array-and-slice-types)-typed expressions can be

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -1,12 +1,12 @@
 # Block expressions
 
-> **<sup>Syntax</sup>**  
-> _BlockExpression_ :  
-> &nbsp;&nbsp; `{`  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Statement_]<sup>\*</sup>  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_]<sup>?</sup>  
-> &nbsp;&nbsp; `}`  
+> **<sup>Syntax</sup>**\
+> _BlockExpression_ :\
+> &nbsp;&nbsp; `{`\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Statement_]<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_]<sup>?</sup>\
+> &nbsp;&nbsp; `}`
 
 A _block expression_ is similar to a module in terms of the declarations that
 are possible, but can also contain [statements] and end with
@@ -30,14 +30,14 @@ let x: i32 = { println!("Hello."); 5 };
 assert_eq!(5, x);
 ```
 
-Blocks are always [value expressions] and evaluate the last expression in 
+Blocks are always [value expressions] and evaluate the last expression in
 value expression context. This can be used to force moving a value if really
 needed.
 
 ## `unsafe` blocks
 
-> **<sup>Syntax</sup>**  
-> _UnsafeBlockExpression_ :  
+> **<sup>Syntax</sup>**\
+> _UnsafeBlockExpression_ :\
 > &nbsp;&nbsp; `unsafe` _BlockExpression_
 
 _See [`unsafe` block](unsafe-blocks.html) for more information on when to use `unsafe`_

--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -1,11 +1,11 @@
 # Call expressions
 
-> **<sup>Syntax</sup>**  
-> _CallExpression_ :  
-> &nbsp;&nbsp; [_Expression_] `(` _CallParams_<sup>?</sup> `)`  
->   
-> _CallParams_ :  
-> &nbsp;&nbsp; [_Expression_]&nbsp;( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>  
+> **<sup>Syntax</sup>**\
+> _CallExpression_ :\
+> &nbsp;&nbsp; [_Expression_] `(` _CallParams_<sup>?</sup> `)`
+>
+> _CallParams_ :\
+> &nbsp;&nbsp; [_Expression_]&nbsp;( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>
 
 A _call expression_ consists of an expression followed by a parenthesized
 expression-list. It invokes a function, providing zero or more input variables.

--- a/src/expressions/closure-expr.md
+++ b/src/expressions/closure-expr.md
@@ -1,10 +1,10 @@
 # Closure expressions
 
-> **<sup>Syntax</sup>**  
-> _ClosureExpression_ :  
-> &nbsp;&nbsp; `move`<sup>?</sup>  
-> &nbsp;&nbsp; ( `||` | `|` [_FunctionParameters_]<sup>?</sup> `|` )  
-> &nbsp;&nbsp; ([_Expression_] | `->` [_TypeNoBounds_]&nbsp;[_BlockExpression_])  
+> **<sup>Syntax</sup>**\
+> _ClosureExpression_ :\
+> &nbsp;&nbsp; `move`<sup>?</sup>\
+> &nbsp;&nbsp; ( `||` | `|` [_FunctionParameters_]<sup>?</sup> `|` )\
+> &nbsp;&nbsp; ([_Expression_] | `->` [_TypeNoBounds_]&nbsp;[_BlockExpression_])
 
 A _closure expression_ defines a closure and denotes it as a value, in a single
 expression. A closure expression is a pipe-symbol-delimited (`|`) list of

--- a/src/expressions/field-expr.md
+++ b/src/expressions/field-expr.md
@@ -1,7 +1,7 @@
 # Field access expressions
 
-> **<sup>Syntax</sup>**  
-> _FieldExpression_ :  
+> **<sup>Syntax</sup>**\
+> _FieldExpression_ :\
 > &nbsp;&nbsp; [_Expression_] `.` [IDENTIFIER]
 
 A _field expression_ consists of an expression followed by a single dot and an

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -1,7 +1,7 @@
 # Grouped expressions
 
-> **<sup>Syntax</sup>**  
-> _GroupedExpression_ :  
+> **<sup>Syntax</sup>**\
+> _GroupedExpression_ :\
 > &nbsp;&nbsp; `(` [_Expression_] `)`
 
 An expression enclosed in parentheses evaluates to the result of the enclosed
@@ -30,7 +30,7 @@ that is a member of a struct:
 #    }
 # }
 # let a = A{f: || "The field f"};
-# 
+#
 assert_eq!( a.f (), "The method f");
 assert_eq!((a.f)(), "The field f");
 ```

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -2,13 +2,13 @@
 
 ## `if` expressions
 
-> **<sup>Syntax</sup>**  
-> _IfExpression_ :  
-> &nbsp;&nbsp; `if` [_Expression_]<sub>_except struct expression_</sub> [_BlockExpression_]  
+> **<sup>Syntax</sup>**\
+> _IfExpression_ :\
+> &nbsp;&nbsp; `if` [_Expression_]<sub>_except struct expression_</sub> [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
 > | _IfExpression_
-> | _IfLetExpression_ ) )<sup>\?</sup>  
+> | _IfLetExpression_ ) )<sup>\?</sup>
 
 An `if` expression is a conditional branch in program control. The form of an
 `if` expression is a condition expression, followed by a consequent block, any
@@ -42,14 +42,14 @@ assert_eq!(y, "Bigger");
 
 ## `if let` expressions
 
-> **<sup>Syntax</sup>**  
-> _IfLetExpression_ :  
+> **<sup>Syntax</sup>**\
+> _IfLetExpression_ :\
 > &nbsp;&nbsp; `if` `let` _Pattern_ `=` [_Expression_]<sub>_except struct expression_</sub>
->              [_BlockExpression_]  
+>              [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
 > | _IfExpression_
-> | _IfLetExpression_ ) )<sup>\?</sup>  
+> | _IfLetExpression_ ) )<sup>\?</sup>
 
 An `if let` expression is semantically similar to an `if` expression but in
 place of a condition expression it expects the keyword `let` followed by a

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -1,16 +1,16 @@
 # Literal expressions
 
-> **<sup>Syntax</sup>**  
-> _LiteralExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]  
-> &nbsp;&nbsp; | [STRING_LITERAL]  
-> &nbsp;&nbsp; | [RAW_STRING_LITERAL]  
-> &nbsp;&nbsp; | [BYTE_LITERAL]  
-> &nbsp;&nbsp; | [BYTE_STRING_LITERAL]  
-> &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]  
-> &nbsp;&nbsp; | [INTEGER_LITERAL]  
-> &nbsp;&nbsp; | [FLOAT_LITERAL]  
-> &nbsp;&nbsp; | [BOOLEAN_LITERAL]  
+> **<sup>Syntax</sup>**\
+> _LiteralExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]\
+> &nbsp;&nbsp; | [STRING_LITERAL]\
+> &nbsp;&nbsp; | [RAW_STRING_LITERAL]\
+> &nbsp;&nbsp; | [BYTE_LITERAL]\
+> &nbsp;&nbsp; | [BYTE_STRING_LITERAL]\
+> &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]\
+> &nbsp;&nbsp; | [INTEGER_LITERAL]\
+> &nbsp;&nbsp; | [FLOAT_LITERAL]\
+> &nbsp;&nbsp; | [BOOLEAN_LITERAL]
 
 A _literal expression_ consists of one of the [literal](tokens.html#literals)
 forms described earlier. It directly describes a number, character, string,

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -1,13 +1,13 @@
 # Loops
 
-> **<sup>Syntax</sup>**  
-> _LoopExpression_ :  
-> &nbsp;&nbsp; [_LoopLabel_]<sup>?</sup> (  
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_InfiniteLoopExpression_]  
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicateLoopExpression_]  
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicatePatternLoopExpression_]  
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_IteratorLoopExpression_]  
-> &nbsp;&nbsp; )  
+> **<sup>Syntax</sup>**\
+> _LoopExpression_ :\
+> &nbsp;&nbsp; [_LoopLabel_]<sup>?</sup> (\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_InfiniteLoopExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicateLoopExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicatePatternLoopExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_IteratorLoopExpression_]\
+> &nbsp;&nbsp; )
 
 [_LoopLabel_]: #loop-labels
 [_InfiniteLoopExpression_]: #infinite-loops
@@ -29,8 +29,8 @@ Only `loop` supports [evaluation to non-trivial values](#break-and-loop-values).
 
 ## Infinite loops
 
-> **<sup>Syntax</sup>**  
-> _InfiniteLoopExpression_ :  
+> **<sup>Syntax</sup>**\
+> _InfiniteLoopExpression_ :\
 > &nbsp;&nbsp; `loop` [_BlockExpression_]
 
 A `loop` expression repeats execution of its body continuously:
@@ -43,8 +43,8 @@ have type compatible with the value of the `break` expression(s).
 
 ## Predicate loops
 
-> **<sup>Syntax</sup>**  
-> _PredicateLoopExpression_ :  
+> **<sup>Syntax</sup>**\
+> _PredicateLoopExpression_ :\
 > &nbsp;&nbsp; `while` [_Expression_]<sub>except struct expression</sub> [_BlockExpression_]
 
 A `while` loop begins by evaluating the boolean loop conditional expression. If
@@ -65,10 +65,10 @@ while i < 10 {
 
 ## Predicate pattern loops
 
-> **<sup>Syntax</sup>**  
-> [_PredicatePatternLoopExpression_] :  
+> **<sup>Syntax</sup>**\
+> [_PredicatePatternLoopExpression_] :\
 > &nbsp;&nbsp; `while` `let` _Pattern_ `=` [_Expression_]<sub>except struct expression</sub>
->              [_BlockExpression_]  
+>              [_BlockExpression_]
 
 A `while let` loop is semantically similar to a `while` loop but in place of a
 condition expression it expects the keyword `let` followed by a refutable
@@ -87,8 +87,8 @@ while let Some(y) = x.pop() {
 
 ## Iterator loops
 
-> **<sup>Syntax</sup>**  
-> _IteratorLoopExpression_ :  
+> **<sup>Syntax</sup>**\
+> _IteratorLoopExpression_ :\
 > &nbsp;&nbsp; `for` _Pattern_ `in` [_Expression_]<sub>except struct expression</sub>
 >              [_BlockExpression_]
 
@@ -120,8 +120,8 @@ assert_eq!(sum, 55);
 
 ## Loop labels
 
-> **<sup>Syntax</sup>**  
-> _LoopLabel_ :  
+> **<sup>Syntax</sup>**\
+> _LoopLabel_ :\
 > &nbsp;&nbsp; [LIFETIME_OR_LABEL] `:`
 
 A loop expression may optionally have a _label_. The label is written as
@@ -134,8 +134,8 @@ expressions](#continue-expressions).
 
 ## `break` expressions
 
-> **<sup>Syntax</sup>**  
-> _BreakExpression_ :  
+> **<sup>Syntax</sup>**\
+> _BreakExpression_ :\
 > &nbsp;&nbsp; `break` [LIFETIME_OR_LABEL]<sup>?</sup> [_Expression_]<sup>?</sup>
 
 When `break` is encountered, execution of the associated loop body is
@@ -170,8 +170,8 @@ the forms `break`, `break 'label` or ([see below](#break-and-loop-values))
 
 ## `continue` expressions
 
-> **<sup>Syntax</sup>**  
-> _ContinueExpression_ :  
+> **<sup>Syntax</sup>**\
+> _ContinueExpression_ :\
 > &nbsp;&nbsp; `continue` [LIFETIME_OR_LABEL]<sup>?</sup>
 
 When `continue` is encountered, the current iteration of the associated loop

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -1,26 +1,26 @@
 # `match` expressions
 
-> **<sup>Syntax</sup>**  
-> _MatchExpression_ :  
-> &nbsp;&nbsp; `match` [_Expression_]<sub>_except struct expression_</sub> `{`  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>  
-> &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>  
-> &nbsp;&nbsp; `}`  
+> **<sup>Syntax</sup>**\
+> _MatchExpression_ :\
+> &nbsp;&nbsp; `match` [_Expression_]<sub>_except struct expression_</sub> `{`\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>\
+> &nbsp;&nbsp; `}`
 >
-> _MatchArms_ :  
+> _MatchArms_ :\
 > &nbsp;&nbsp; ( _MatchArm_ `=>`
 >                             ( [_BlockExpression_] `,`<sup>?</sup>
 >                             | [_Expression_] `,` )
->                           )<sup>\*</sup>  
-> &nbsp;&nbsp; _MatchArm_ `=>` ( [_BlockExpression_] | [_Expression_] ) `,`<sup>?</sup>  
+>                           )<sup>\*</sup>\
+> &nbsp;&nbsp; _MatchArm_ `=>` ( [_BlockExpression_] | [_Expression_] ) `,`<sup>?</sup>
 >
-> _MatchArm_ :  
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> _MatchArmPatterns_ _MatchArmGuard_<sup>?</sup>  
+> _MatchArm_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> _MatchArmPatterns_ _MatchArmGuard_<sup>?</sup>
 >
-> _MatchArmPatterns_ :  
-> &nbsp;&nbsp; `|`<sup>?</sup> _Pattern_ ( `|` _Pattern_ )<sup>\*</sup>  
+> _MatchArmPatterns_ :\
+> &nbsp;&nbsp; `|`<sup>?</sup> _Pattern_ ( `|` _Pattern_ )<sup>\*</sup>
 >
-> _MatchArmGuard_ :  
+> _MatchArmGuard_ :\
 > &nbsp;&nbsp; `if` [_Expression_]
 
 A `match` expression branches on a *pattern*. The exact form of matching that

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -1,17 +1,17 @@
 # Operator expressions
 
-> **<sup>Syntax</sup>**  
-> _OperatorExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_BorrowExpression_]  
-> &nbsp;&nbsp; | [_DereferenceExpression_]  
-> &nbsp;&nbsp; | [_ErrorPropagationExpression_]  
-> &nbsp;&nbsp; | [_NegationExpression_]  
-> &nbsp;&nbsp; | [_ArithmeticOrLogicalExpression_]  
-> &nbsp;&nbsp; | [_ComparisonExpression_]  
-> &nbsp;&nbsp; | [_LazyBooleanExpression_]  
-> &nbsp;&nbsp; | [_TypeCastExpression_]  
-> &nbsp;&nbsp; | [_AssignmentExpression_]  
-> &nbsp;&nbsp; | [_CompoundAssignmentExpression_]  
+> **<sup>Syntax</sup>**\
+> _OperatorExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_BorrowExpression_]\
+> &nbsp;&nbsp; | [_DereferenceExpression_]\
+> &nbsp;&nbsp; | [_ErrorPropagationExpression_]\
+> &nbsp;&nbsp; | [_NegationExpression_]\
+> &nbsp;&nbsp; | [_ArithmeticOrLogicalExpression_]\
+> &nbsp;&nbsp; | [_ComparisonExpression_]\
+> &nbsp;&nbsp; | [_LazyBooleanExpression_]\
+> &nbsp;&nbsp; | [_TypeCastExpression_]\
+> &nbsp;&nbsp; | [_AssignmentExpression_]\
+> &nbsp;&nbsp; | [_CompoundAssignmentExpression_]
 
 Operators are defined for built in types by the Rust language. Many of the
 following operators can also be overloaded using traits in `std::ops` or
@@ -34,10 +34,10 @@ overflow:
 
 ## Borrow operators
 
-> **<sup>Syntax</sup>**  
-> _BorrowExpression_ :   
-> &nbsp;&nbsp; &nbsp;&nbsp; (`&`|`&&`) [_Expression_]  
-> &nbsp;&nbsp; | (`&`|`&&`) `mut` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _BorrowExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; (`&`|`&&`) [_Expression_]\
+> &nbsp;&nbsp; | (`&`|`&&`) `mut` [_Expression_]
 
 The `&` (shared borrow) and `&mut` (mutable borrow) operators are unary prefix
 operators. When applied to a [place expression], this expressions produces a
@@ -80,14 +80,14 @@ let a = & & & & mut 10;
 
 ## The dereference operator
 
-> **<sup>Syntax</sup>**  
-> _DereferenceExpression_ :  
+> **<sup>Syntax</sup>**\
+> _DereferenceExpression_ :\
 > &nbsp;&nbsp; `*` [_Expression_]
 
 The `*` (dereference) operator is also a unary prefix operator. When applied to
 a [pointer](types.html#pointer-types) it denotes the pointed-to location. If
 the expression is of type `&mut T` and `*mut T`, and is either a local
-variable, a (nested) field of a local variable or is a mutable [place 
+variable, a (nested) field of a local variable or is a mutable [place
 expression], then the resulting memory location can be assigned to.
 Dereferencing a raw pointer requires `unsafe`.
 
@@ -105,15 +105,15 @@ assert_eq!(*y, 11);
 
 ## The question mark operator
 
-> **<sup>Syntax</sup>**  
-> _ErrorPropagationExpression_ :  
-> &nbsp;&nbsp; [_Expression_] `?`  
+> **<sup>Syntax</sup>**\
+> _ErrorPropagationExpression_ :\
+> &nbsp;&nbsp; [_Expression_] `?`
 
 The question mark operator (`?`) unwraps valid values or returns erroneous
 values, propagating them to the calling function. It is a unary postfix
 operator that can only be applied to the types `Result<T, E>` and `Option<T>`.
 
-When applied to values of the `Result<T, E>` type, it propagates errors. If 
+When applied to values of the `Result<T, E>` type, it propagates errors. If
 the value is `Err(e)`, then it will return `Err(From::from(e))` from the
 enclosing function or closure. If applied to `Ok(x)`, then it will unwrap the
 value to evaluate to `x`.
@@ -153,10 +153,10 @@ assert_eq!(try_option_none(), None);
 
 ## Negation operators
 
-> **<sup>Syntax</sup>**  
-> _NegationExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `-` [_Expression_]  
-> &nbsp;&nbsp; | `!` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _NegationExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `-` [_Expression_]\
+> &nbsp;&nbsp; | `!` [_Expression_]
 
 These are the last two unary operators. This table summarizes the behavior of
 them on primitive types and which traits are used to overload these operators
@@ -182,18 +182,18 @@ assert_eq!(true, !false);
 
 ## Arithmetic and Logical Binary Operators
 
-> **<sup>Syntax</sup>**  
-> _ArithmeticOrLogicalExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `-` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `*` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `/` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `%` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `&` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `|` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `^` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `<<` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `>>` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _ArithmeticOrLogicalExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `-` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `*` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `/` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `%` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `&` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `|` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `^` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<<` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>>` [_Expression_]
 
 Binary operators expressions are all written with infix notation. This table
 summarizes the behavior of arithmetic and logical binary operators on
@@ -237,14 +237,14 @@ assert_eq!(-10 >> 2, -3);
 
 ## Comparison Operators
 
-> **<sup>Syntax</sup>**  
-> _ComparisonExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `==` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `!=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `>` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `<` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `>=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `<=` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _ComparisonExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `==` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `!=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<=` [_Expression_]
 
 Comparison operators are also defined both for primitive types and many type in
 the standard library. Parentheses are required when chaining comparison
@@ -290,9 +290,9 @@ assert!("World" >= "Hello");
 
 ## Lazy boolean operators
 
-> **<sup>Syntax</sup>**  
-> _LazyBooleanExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `||` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _LazyBooleanExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `||` [_Expression_]\
 > &nbsp;&nbsp; | [_Expression_] `&&` [_Expression_]
 
 The operators `||` and `&&` may be applied to operands of boolean type. The
@@ -310,8 +310,8 @@ let y = false && panic!(); // false, doesn't evaluate `panic!()`
 
 ## Type cast expressions
 
-> **<sup>Syntax</sup>**  
-> _TypeCastExpression_ :  
+> **<sup>Syntax</sup>**\
+> _TypeCastExpression_ :\
 > &nbsp;&nbsp; [_Expression_] `as` [_PathInExpression_]
 
 A type cast expression is denoted with the binary operator `as`.
@@ -390,9 +390,9 @@ same trait object.
 
 ## Assignment expressions
 
-> **<sup>Syntax</sup>**  
-> _AssignmentExpression_ :  
-> &nbsp;&nbsp; | [_Expression_] `=` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _AssignmentExpression_ :\
+> &nbsp;&nbsp; | [_Expression_] `=` [_Expression_]
 
 An _assignment expression_ consists of a [place expression] followed by an
 equals sign (`=`) and a [value expression]. Such an expression always has
@@ -413,18 +413,18 @@ x = y;
 
 ## Compound assignment expressions
 
-> **<sup>Syntax</sup>**  
-> _CompoundAssignmentExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `-=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `*=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `/=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `%=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `&=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `|=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `^=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `<<=` [_Expression_]  
-> &nbsp;&nbsp; | [_Expression_] `>>=` [_Expression_]  
+> **<sup>Syntax</sup>**\
+> _CompoundAssignmentExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `-=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `*=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `/=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `%=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `&=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `|=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `^=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<<=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>>=` [_Expression_]
 
 The `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, and `>>` operators may be
 composed with the `=` operator. The expression `place_exp OP= value` is

--- a/src/expressions/range-expr.md
+++ b/src/expressions/range-expr.md
@@ -1,31 +1,31 @@
 # Range expressions
 
-> **<sup>Syntax</sup>**  
-> _RangeExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangeExpr_  
-> &nbsp;&nbsp; | _RangeFromExpr_  
-> &nbsp;&nbsp; | _RangeToExpr_  
-> &nbsp;&nbsp; | _RangeFullExpr_  
-> &nbsp;&nbsp; | _RangeInclusiveExpr_  
-> &nbsp;&nbsp; | _RangeToInclusiveExpr_  
->  
-> _RangeExpr_ :  
-> &nbsp;&nbsp; [_Expression_] `..` [_Expression_]  
->  
-> _RangeFromExpr_ :  
-> &nbsp;&nbsp; [_Expression_] `..`  
->  
-> _RangeToExpr_ :  
-> &nbsp;&nbsp; `..` [_Expression_]  
->  
-> _RangeFullExpr_ :  
-> &nbsp;&nbsp; `..`  
+> **<sup>Syntax</sup>**\
+> _RangeExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; _RangeExpr_\
+> &nbsp;&nbsp; | _RangeFromExpr_\
+> &nbsp;&nbsp; | _RangeToExpr_\
+> &nbsp;&nbsp; | _RangeFullExpr_\
+> &nbsp;&nbsp; | _RangeInclusiveExpr_\
+> &nbsp;&nbsp; | _RangeToInclusiveExpr_
 >
-> _RangeExpr_ :  
-> &nbsp;&nbsp; [_Expression_] `..=` [_Expression_]  
->  
-> _RangeToExpr_ :  
-> &nbsp;&nbsp; `..=` [_Expression_]  
+> _RangeExpr_ :\
+> &nbsp;&nbsp; [_Expression_] `..` [_Expression_]
+>
+> _RangeFromExpr_ :\
+> &nbsp;&nbsp; [_Expression_] `..`
+>
+> _RangeToExpr_ :\
+> &nbsp;&nbsp; `..` [_Expression_]
+>
+> _RangeFullExpr_ :\
+> &nbsp;&nbsp; `..`
+>
+> _RangeExpr_ :\
+> &nbsp;&nbsp; [_Expression_] `..=` [_Expression_]
+>
+> _RangeToExpr_ :\
+> &nbsp;&nbsp; `..=` [_Expression_]
 
 The `..` and `..=` operators will construct an object of one of the
 `std::ops::Range` (or `core::ops::Range`) variants, according to the following

--- a/src/expressions/return-expr.md
+++ b/src/expressions/return-expr.md
@@ -1,8 +1,8 @@
 # `return` expressions
 
-> **<sup>Syntax</sup>**  
-> _ReturnExpression_ :  
-> &nbsp;&nbsp; `return` [_Expression_]<sup>?</sup>  
+> **<sup>Syntax</sup>**\
+> _ReturnExpression_ :\
+> &nbsp;&nbsp; `return` [_Expression_]<sup>?</sup>
 
 Return expressions are denoted with the keyword `return`. Evaluating a `return`
 expression moves its argument into the designated output location for the

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -11,7 +11,7 @@ containing no underscores and with no leading zeros or integer suffix. A value
 of a [union](items/unions.html) type can also be created using this syntax,
 except that it must specify exactly one field.
 
-Struct expressions can't be used directly in the head of a [loop] 
+Struct expressions can't be used directly in the head of a [loop]
 or an [if], [if let] or [match] expression. But struct expressions can still be
 in used inside parentheses, for example.
 

--- a/src/expressions/tuple-expr.md
+++ b/src/expressions/tuple-expr.md
@@ -2,9 +2,9 @@
 
 ## Tuple expressions
 
-> **<sup>Syntax</sup>**  
-> _TupleExpression_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` `)`  
+> **<sup>Syntax</sup>**\
+> _TupleExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `(` `)`\
 > &nbsp;&nbsp; | `(` ( [_Expression_] `,` )<sup>+</sup> [_Expression_]<sup>?</sup> `)`
 
 Tuples are written by enclosing zero or more comma-separated expressions in
@@ -27,8 +27,8 @@ comma:
 
 ## Tuple indexing expressions
 
-> **<sup>Syntax</sup>**  
-> _TupleIndexingExpression_ :  
+> **<sup>Syntax</sup>**\
+> _TupleIndexingExpression_ :\
 > &nbsp;&nbsp; [_Expression_] `.` [TUPLE_INDEX]
 
 [Tuples](types.html#tuple-types) and [struct tuples](items/structs.html) can be

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -73,7 +73,7 @@ Types that can be referred to by a path directly. Specifically [enums],
 ### Object Safe Traits
 
 [Traits] that can be used as [trait objects]. Only traits that follow specific
-[rules][object safety] are object safe. 
+[rules][object safety] are object safe.
 
 ### Prelude
 

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -1,11 +1,11 @@
 # Identifiers
 
-> **<sup>Lexer:<sup>**  
-> IDENTIFIER_OR_KEYWORD :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [`a`-`z` `A`-`Z`]&nbsp;[`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>\*</sup>  
-> &nbsp;&nbsp; | `_` [`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>+</sup>  
->  
-> IDENTIFIER :  
+> **<sup>Lexer:<sup>**\
+> IDENTIFIER_OR_KEYWORD :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [`a`-`z` `A`-`Z`]&nbsp;[`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>\*</sup>\
+> &nbsp;&nbsp; | `_` [`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>+</sup>
+>
+> IDENTIFIER :\
 > IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub>
 
 An identifier is any nonempty ASCII string of the following form:

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -147,12 +147,12 @@ finally an optional list of trait bounds.
 The identifier is the name of the declared type alias. The optional trait bounds
 must be fulfilled by the implementations of the type alias.
 
-An *associated type definition* defines a type alias on another type. It is 
+An *associated type definition* defines a type alias on another type. It is
 written as `type`, then an [identifier], then an `=`, and finally a [type].
 
-If a type `Item` has an associated type `Assoc` from a trait `Trait`, then 
+If a type `Item` has an associated type `Assoc` from a trait `Trait`, then
 `<Item as Trait>::Assoc` is a type that is an alias of the type specified in the
-associated type definition. Furthermore, if `Item` is a type parameter, then 
+associated type definition. Furthermore, if `Item` is a type parameter, then
 `Item::Assoc` can be used in type parameters.
 
 ```rust

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -1,29 +1,29 @@
 # Enumerations
 
-> **<sup>Syntax</sup>**  
-> _Enumeration_ :  
+> **<sup>Syntax</sup>**\
+> _Enumeration_ :\
 > &nbsp;&nbsp; `enum`
 >    [IDENTIFIER]&nbsp;
 >    [_Generics_]<sup>?</sup>
 >    [_WhereClause_]<sup>?</sup>
->    `{` _EnumItems_<sup>?</sup> `}`  
->  
-> _EnumItems_ :  
-> &nbsp;&nbsp; _EnumItem_ ( `,` _EnumItem_ )<sup>\*</sup> `,`<sup>?</sup>  
->  
-> _EnumItem_ :  
-> &nbsp;&nbsp; _OuterAttribute_<sup>\*</sup>  
-> &nbsp;&nbsp; [IDENTIFIER]&nbsp;( _EnumItemTuple_ | _EnumItemStruct_ 
->                                | _EnumItemDiscriminant_ )<sup>?</sup>  
->  
-> _EnumItemTuple_ :  
-> &nbsp;&nbsp; `(` [_TupleFields_]<sup>?</sup> `)`  
->   
-> _EnumItemStruct_ :  
-> &nbsp;&nbsp; `{` [_StructFields_]<sup>?</sup> `}`  
->   
-> _EnumItemDiscriminant_ :  
-> &nbsp;&nbsp; `=` [_Expression_]  
+>    `{` _EnumItems_<sup>?</sup> `}`
+>
+> _EnumItems_ :\
+> &nbsp;&nbsp; _EnumItem_ ( `,` _EnumItem_ )<sup>\*</sup> `,`<sup>?</sup>
+>
+> _EnumItem_ :\
+> &nbsp;&nbsp; _OuterAttribute_<sup>\*</sup>\
+> &nbsp;&nbsp; [IDENTIFIER]&nbsp;( _EnumItemTuple_ | _EnumItemStruct_
+>                                | _EnumItemDiscriminant_ )<sup>?</sup>
+>
+> _EnumItemTuple_ :\
+> &nbsp;&nbsp; `(` [_TupleFields_]<sup>?</sup> `)`
+>
+> _EnumItemStruct_ :\
+> &nbsp;&nbsp; `{` [_StructFields_]<sup>?</sup> `}`
+>
+> _EnumItemDiscriminant_ :\
+> &nbsp;&nbsp; `=` [_Expression_]
 
 An *enumeration*, also referred to as *enum* is a simultaneous definition of a
 nominal [enumerated type] as well as a set of *constructors*, that can be used

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -1,7 +1,7 @@
 # Extern crate declarations
 
-> **<sup>Syntax:<sup>**  
-> _ExternCrate_ :  
+> **<sup>Syntax:<sup>**\
+> _ExternCrate_ :\
 > &nbsp;&nbsp; `extern` `crate` [IDENTIFIER]&nbsp;(`as` [IDENTIFIER])<sup>?</sup> `;`
 
 An _`extern crate` declaration_ specifies a dependency on an external crate.

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -1,24 +1,24 @@
 # Type and Lifetime Parameters
 
-> **<sup>Syntax</sup>**  
-> _Generics_ :  
-> &nbsp;&nbsp; `<` _GenericParams_ `>`  
->  
-> _GenericParams_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; _LifetimeParams_  
-> &nbsp;&nbsp; | ( _LifetimeParam_ `,` )<sup>\*</sup> _TypeParams_  
->  
-> _LifetimeParams_ :  
-> &nbsp;&nbsp; ( _LifetimeParam_ `,` )<sup>\*</sup> _LifetimeParam_<sup>?</sup>  
->  
-> _LifetimeParam_ :  
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>?</sup> [LIFETIME_OR_LABEL] `:` [_LifetimeBounds_]<sup>?</sup>  
->  
-> _TypeParams_:  
-> &nbsp;&nbsp; ( _TypeParam_ `,` )<sup>\*</sup> _TypeParam_ <sup>?</sup>  
->  
-> _TypeParam_ :  
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>?</sup> [IDENTIFIER] ( `:` [_TypeParamBounds_] )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>  
+> **<sup>Syntax</sup>**\
+> _Generics_ :\
+> &nbsp;&nbsp; `<` _GenericParams_ `>`
+>
+> _GenericParams_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; _LifetimeParams_\
+> &nbsp;&nbsp; | ( _LifetimeParam_ `,` )<sup>\*</sup> _TypeParams_
+>
+> _LifetimeParams_ :\
+> &nbsp;&nbsp; ( _LifetimeParam_ `,` )<sup>\*</sup> _LifetimeParam_<sup>?</sup>
+>
+> _LifetimeParam_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>?</sup> [LIFETIME_OR_LABEL] `:` [_LifetimeBounds_]<sup>?</sup>
+>
+> _TypeParams_:\
+> &nbsp;&nbsp; ( _TypeParam_ `,` )<sup>\*</sup> _TypeParam_ <sup>?</sup>
+>
+> _TypeParam_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>?</sup> [IDENTIFIER] ( `:` [_TypeParamBounds_] )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>
 
 Functions, type aliases, structs, enumerations, unions, traits and
 implementations may be *parameterized* by types and lifetimes. These parameters
@@ -40,22 +40,22 @@ referred to with path syntax.
 
 ## Where clauses
 
-> **<sup>Syntax</sup>**  
-> _WhereClause_ :  
-> &nbsp;&nbsp; `where` ( _WhereClauseItem_ `,` )<sup>\*</sup> _WhereClauseItem_ <sup>?</sup>  
->  
-> _WhereClauseItem_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; _LifetimeWhereClauseItem_  
-> &nbsp;&nbsp; | _TypeBoundWhereClauseItem_  
->  
-> _LifetimeWhereClauseItem_ :  
-> &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]  
->  
-> _TypeBoundWhereClauseItem_ :  
-> &nbsp;&nbsp; _ForLifetimes_<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>  
->  
-> _ForLifetimes_ :  
-> &nbsp;&nbsp; `for` `<` [_LifetimeParams_](#type-and-lifetime-parameters) `>`  
+> **<sup>Syntax</sup>**\
+> _WhereClause_ :\
+> &nbsp;&nbsp; `where` ( _WhereClauseItem_ `,` )<sup>\*</sup> _WhereClauseItem_ <sup>?</sup>
+>
+> _WhereClauseItem_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; _LifetimeWhereClauseItem_\
+> &nbsp;&nbsp; | _TypeBoundWhereClauseItem_
+>
+> _LifetimeWhereClauseItem_ :\
+> &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]
+>
+> _TypeBoundWhereClauseItem_ :\
+> &nbsp;&nbsp; _ForLifetimes_<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>
+>
+> _ForLifetimes_ :\
+> &nbsp;&nbsp; `for` `<` [_LifetimeParams_](#type-and-lifetime-parameters) `>`
 
 *Where clauses* provide an another way to specify bounds on type and lifetime
 parameters as well as a way to specify bounds on types that aren't type

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -2,7 +2,7 @@
 
 An _implementation_ is an item that associates items with an *implementing type*.
 
-There are two types of implementations: inherent implementations and [trait] 
+There are two types of implementations: inherent implementations and [trait]
 implementations.
 
 Implementations are defined with the keyword `impl`.
@@ -53,7 +53,7 @@ The trait is known as the *implemented trait*.
 The implementing type implements the implemented trait.
 
 A trait implementation must define all non-default associated items declared
-by the implemented trait, may redefine default associated items defined by the 
+by the implemented trait, may redefine default associated items defined by the
 implemented trait, and cannot define any other items.
 
 The path to the associated items is `<` followed by a path to the implementing
@@ -95,11 +95,11 @@ impl Shape for Circle {
 ### Trait Implementation Coherence
 
 A trait implementation is considered incoherent if either the orphan check fails
-or there are overlapping implementation instances. 
+or there are overlapping implementation instances.
 
 Two trait implementations overlap when there is a non-empty intersection of the
 traits the implementation is for, the implementations can be instantiated with
-the same type. <!-- This is probably wrong? Source: No two implementations can 
+the same type. <!-- This is probably wrong? Source: No two implementations can
 be instantiable with the same set of types for the input type parameters. -->
 
 The `Orphan Check` states that every trait implementation must meet either of

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -1,12 +1,12 @@
 # Modules
 
-> **<sup>Syntax:<sup>**  
-> _Module_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `mod` [IDENTIFIER] `;`  
-> &nbsp;&nbsp; | `mod` [IDENTIFIER] `{`  
-> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>  
-> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_Item_]<sup>\*</sup>  
-> &nbsp;&nbsp; &nbsp;&nbsp; `}`  
+> **<sup>Syntax:<sup>**\
+> _Module_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `mod` [IDENTIFIER] `;`\
+> &nbsp;&nbsp; | `mod` [IDENTIFIER] `{`\
+> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_Item_]<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; `}`
 
 A module is a container for zero or more [items].
 

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -1,7 +1,7 @@
 # Static items
 
-> **<sup>Syntax</sup>**  
-> _StaticItem_ :  
+> **<sup>Syntax</sup>**\
+> _StaticItem_ :\
 > &nbsp;&nbsp; `static` `mut`<sup>?</sup> [IDENTIFIER] `:` [_Type_]
 >              `=` [_Expression_] `;`
 

--- a/src/items/structs.md
+++ b/src/items/structs.md
@@ -1,40 +1,40 @@
 # Structs
 
-> **<sup>Syntax</sup>**  
-> _Struct_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; _StructStruct_  
-> &nbsp;&nbsp; | _TupleStruct_  
->  
-> _StructStruct_ :  
+> **<sup>Syntax</sup>**\
+> _Struct_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; _StructStruct_\
+> &nbsp;&nbsp; | _TupleStruct_
+>
+> _StructStruct_ :\
 > &nbsp;&nbsp; `struct`
 >   [IDENTIFIER]&nbsp;
 >   [_Generics_]<sup>?</sup>
 >   [_WhereClause_]<sup>?</sup>
->   ( `{` _StructFields_<sup>?</sup> `}` | `;` )  
->  
-> _TupleStruct_ :  
+>   ( `{` _StructFields_<sup>?</sup> `}` | `;` )
+>
+> _TupleStruct_ :\
 > &nbsp;&nbsp; `struct`
 >   [IDENTIFIER]&nbsp;
 >   [_Generics_]<sup>?</sup>
 >   `(` _TupleFields_<sup>?</sup> `)`
 >   [_WhereClause_]<sup>?</sup>
->   `;`  
->  
-> _StructFields_ :  
-> &nbsp;&nbsp; _StructField_ (`,` _StructField_)<sup>\*</sup> `,`<sup>?</sup>  
->  
-> _StructField_ :  
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>  
+>   `;`
+>
+> _StructFields_ :\
+> &nbsp;&nbsp; _StructField_ (`,` _StructField_)<sup>\*</sup> `,`<sup>?</sup>
+>
+> _StructField_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; [_Visibility_]
-> &nbsp;&nbsp; [IDENTIFIER] `:` [_Type_]  
->  
-> _TupleFields_ :  
-> &nbsp;&nbsp; _TupleField_ (`,` _TupleField_)<sup>\*</sup> `,`<sup>?</sup>  
->  
-> _TupleField_ :  
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>  
+> &nbsp;&nbsp; [IDENTIFIER] `:` [_Type_]
+>
+> _TupleFields_ :\
+> &nbsp;&nbsp; _TupleField_ (`,` _TupleField_)<sup>\*</sup> `,`<sup>?</sup>
+>
+> _TupleField_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; [_Visibility_]
-> &nbsp;&nbsp; [_Type_]  
+> &nbsp;&nbsp; [_Type_]
 
 A _struct_ is a nominal [struct type] defined with the keyword `struct`.
 

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -1,9 +1,9 @@
 # Type aliases
 
-> **<sup>Syntax</sup>**  
-> _TypeAlias_ :  
+> **<sup>Syntax</sup>**\
+> _TypeAlias_ :\
 > &nbsp;&nbsp; `type` [IDENTIFIER]&nbsp;[_Generics_]<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> `=` [_Type_] `;`  
+>              [_WhereClause_]<sup>?</sup> `=` [_Type_] `;`
 
 A _type alias_ defines a new name for an existing [type]. Type aliases are
 declared with the keyword `type`. Every value has a single, specific type, but

--- a/src/items/unions.md
+++ b/src/items/unions.md
@@ -1,7 +1,7 @@
 # Unions
 
-> **<sup>Syntax</sup>**  
-> _Union_ :  
+> **<sup>Syntax</sup>**\
+> _Union_ :\
 > &nbsp;&nbsp; `union` [IDENTIFIER]&nbsp;[_Generics_]<sup>?</sup> [_WhereClause_]<sup>?</sup>
 >   `{`[_StructFields_] `}`
 

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -1,13 +1,13 @@
 # Use declarations
 
-> **<sup>Syntax:</sup>**  
-> _UseDeclaration_ :  
-> &nbsp;&nbsp; ([_Visibility_])<sup>?</sup> `use` _UseTree_ `;`  
->  
-> _UseTree_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `*`  
-> &nbsp;&nbsp; | ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `{` (_UseTree_ ( `,`  _UseTree_ )<sup>\*</sup> `,`<sup>?</sup>)<sup>?</sup> `}`  
-> &nbsp;&nbsp; | [_SimplePath_] `as` [IDENTIFIER]  
+> **<sup>Syntax:</sup>**\
+> _UseDeclaration_ :\
+> &nbsp;&nbsp; ([_Visibility_])<sup>?</sup> `use` _UseTree_ `;`
+>
+> _UseTree_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `*`\
+> &nbsp;&nbsp; | ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `{` (_UseTree_ ( `,`  _UseTree_ )<sup>\*</sup> `,`<sup>?</sup>)<sup>?</sup> `}`\
+> &nbsp;&nbsp; | [_SimplePath_] `as` [IDENTIFIER]
 
 A _use declaration_ creates one or more local name bindings synonymous with
 some other [path]. Usually a `use` declaration is used to shorten the path

--- a/src/keywords.md
+++ b/src/keywords.md
@@ -20,42 +20,42 @@ be used as the names of:
 * [Macro placeholders]
 * [Crates]
 
-> **<sup>Lexer:<sup>**  
-> KW_AS             : `as`  
-> KW_BREAK          : `break`  
-> KW_CONST          : `const`  
-> KW_CONTINUE       : `continue`  
-> KW_CRATE          : `crate`  
-> KW_ELSE           : `else`  
-> KW_ENUM           : `enum`  
-> KW_EXTERN         : `extern`  
-> KW_FALSE          : `false`  
-> KW_FN             : `fn`  
-> KW_FOR            : `for`  
-> KW_IF             : `if`  
-> KW_IMPL           : `impl`  
-> KW_IN             : `in`  
-> KW_LET            : `let`  
-> KW_LOOP           : `loop`  
-> KW_MATCH          : `match`  
-> KW_MOD            : `mod`  
-> KW_MOVE           : `move`  
-> KW_MUT            : `mut`  
-> KW_PUB            : `pub`  
-> KW_REF            : `ref`  
-> KW_RETURN         : `return`  
-> KW_SELFVALUE      : `self`  
-> KW_SELFTYPE       : `Self`  
-> KW_STATIC         : `static`  
-> KW_STRUCT         : `struct`  
-> KW_SUPER          : `super`  
-> KW_TRAIT          : `trait`  
-> KW_TRUE           : `true`  
-> KW_TYPE           : `type`  
-> KW_UNSAFE         : `unsafe`  
-> KW_USE            : `use`  
-> KW_WHERE          : `where`  
-> KW_WHILE          : `while`  
+> **<sup>Lexer:<sup>**\
+> KW_AS             : `as`\
+> KW_BREAK          : `break`\
+> KW_CONST          : `const`\
+> KW_CONTINUE       : `continue`\
+> KW_CRATE          : `crate`\
+> KW_ELSE           : `else`\
+> KW_ENUM           : `enum`\
+> KW_EXTERN         : `extern`\
+> KW_FALSE          : `false`\
+> KW_FN             : `fn`\
+> KW_FOR            : `for`\
+> KW_IF             : `if`\
+> KW_IMPL           : `impl`\
+> KW_IN             : `in`\
+> KW_LET            : `let`\
+> KW_LOOP           : `loop`\
+> KW_MATCH          : `match`\
+> KW_MOD            : `mod`\
+> KW_MOVE           : `move`\
+> KW_MUT            : `mut`\
+> KW_PUB            : `pub`\
+> KW_REF            : `ref`\
+> KW_RETURN         : `return`\
+> KW_SELFVALUE      : `self`\
+> KW_SELFTYPE       : `Self`\
+> KW_STATIC         : `static`\
+> KW_STRUCT         : `struct`\
+> KW_SUPER          : `super`\
+> KW_TRAIT          : `trait`\
+> KW_TRUE           : `true`\
+> KW_TYPE           : `type`\
+> KW_UNSAFE         : `unsafe`\
+> KW_USE            : `use`\
+> KW_WHERE          : `where`\
+> KW_WHILE          : `while`
 
 ## Reserved keywords
 
@@ -64,19 +64,19 @@ the same restrictions as strict keywords. The reasoning behind this is to make
 current programs forward compatible with future versions of Rust by forbidding
 them to use these keywords.
 
-> **<sup>Lexer</sup>**  
-> KW_ABSTRACT       : `abstract`  
-> KW_BECOME         : `become`  
-> KW_BOX            : `box`  
-> KW_DO             : `do`  
-> KW_FINAL          : `final`  
-> KW_MACRO          : `macro`  
-> KW_OVERRIDE       : `override`  
-> KW_PRIV           : `priv`  
-> KW_TYPEOF         : `typeof`  
-> KW_UNSIZED        : `unsized`  
-> KW_VIRTUAL        : `virtual`  
-> KW_YIELD          : `yield`  
+> **<sup>Lexer</sup>**\
+> KW_ABSTRACT       : `abstract`\
+> KW_BECOME         : `become`\
+> KW_BOX            : `box`\
+> KW_DO             : `do`\
+> KW_FINAL          : `final`\
+> KW_MACRO          : `macro`\
+> KW_OVERRIDE       : `override`\
+> KW_PRIV           : `priv`\
+> KW_TYPEOF         : `typeof`\
+> KW_UNSIZED        : `unsized`\
+> KW_VIRTUAL        : `virtual`\
+> KW_YIELD          : `yield`
 
 ## Weak keywords
 
@@ -87,7 +87,7 @@ is possible to declare a variable or method with the name `union`.
   union declaration.
 * `'static` is used for the static lifetime and cannot be used as a generic
   lifetime parameter
-  
+
   ```compile_fail
   // error[E0262]: invalid lifetime parameter name: `'static`
   fn invalid_lifetime_parameter<'static>(s: &'static str) -> &'static str { s }
@@ -95,9 +95,9 @@ is possible to declare a variable or method with the name `union`.
 * `dyn` denotes a [trait object] and is a keyword when used in a type position
   followed by a path that does not start with `::`.
 
-> **<sup>Lexer</sup>**  
-> KW_UNION          : `union`
-> KW_STATICLIFETIME : `'static`
+> **<sup>Lexer</sup>**\
+> KW_UNION          : `union`\
+> KW_STATICLIFETIME : `'static`\
 > KW_DYN            : `dyn`
 
 [items]: items.html

--- a/src/paths.md
+++ b/src/paths.md
@@ -115,7 +115,7 @@ implementations, it is the canonical path of the item being implemented
 surrounded by <span class="parenthetical">angle (`<>`)</span> brackets. For
 trait implementations, it is the canonical path of the item being implemented
 followed by `as` followed by the canonical path to the trait all surrounded in
-<span class="parenthetical">angle (`<>`)</span> brackets. 
+<span class="parenthetical">angle (`<>`)</span> brackets.
 
 The canonical path is only meaningful within a given crate. There is no global
 namespace across crates; an item's canonical path merely identifies it within

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -87,19 +87,19 @@ evaluated (primarily) at compile time.
 
 #### Character literals
 
-> **<sup>Lexer</sup>**  
-> CHAR_LITERAL :  
-> &nbsp;&nbsp; `'` ( ~[`'` `\` \\n \\r \\t] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE ) `'`  
->  
-> QUOTE_ESCAPE :  
-> &nbsp;&nbsp; `\'` | `\"`  
->  
-> ASCII_ESCAPE :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `\x` OCT_DIGIT HEX_DIGIT  
-> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`  
->  
-> UNICODE_ESCAPE :  
-> &nbsp;&nbsp; `\u{` ( HEX_DIGIT `_`<sup>\*</sup> )<sup>1..6</sup> `}`  
+> **<sup>Lexer</sup>**\
+> CHAR_LITERAL :\
+> &nbsp;&nbsp; `'` ( ~[`'` `\` \\n \\r \\t] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE ) `'`
+>
+> QUOTE_ESCAPE :\
+> &nbsp;&nbsp; `\'` | `\"`
+>
+> ASCII_ESCAPE :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `\x` OCT_DIGIT HEX_DIGIT\
+> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`
+>
+> UNICODE_ESCAPE :\
+> &nbsp;&nbsp; `\u{` ( HEX_DIGIT `_`<sup>\*</sup> )<sup>1..6</sup> `}`
 
 A _character literal_ is a single Unicode character enclosed within two
 `U+0027` (single-quote) characters, with the exception of `U+0027` itself,
@@ -107,18 +107,18 @@ which must be _escaped_ by a preceding `U+005C` character (`\`).
 
 #### String literals
 
-> **<sup>Lexer</sup>**  
-> STRING_LITERAL :  
-> &nbsp;&nbsp; `"` (  
-> &nbsp;&nbsp; &nbsp;&nbsp; ~[`"` `\` _IsolatedCR_]  
-> &nbsp;&nbsp; &nbsp;&nbsp; | QUOTE_ESCAPE  
-> &nbsp;&nbsp; &nbsp;&nbsp; | ASCII_ESCAPE  
-> &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE  
-> &nbsp;&nbsp; &nbsp;&nbsp; | STRING_CONTINUE  
-> &nbsp;&nbsp; )<sup>\*</sup> `"`  
->  
-> STRING_CONTINUE :  
-> &nbsp;&nbsp; `\` _followed by_ \\n  
+> **<sup>Lexer</sup>**\
+> STRING_LITERAL :\
+> &nbsp;&nbsp; `"` (\
+> &nbsp;&nbsp; &nbsp;&nbsp; ~[`"` `\` _IsolatedCR_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | QUOTE_ESCAPE\
+> &nbsp;&nbsp; &nbsp;&nbsp; | ASCII_ESCAPE\
+> &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE\
+> &nbsp;&nbsp; &nbsp;&nbsp; | STRING_CONTINUE\
+> &nbsp;&nbsp; )<sup>\*</sup> `"`
+>
+> STRING_CONTINUE :\
+> &nbsp;&nbsp; `\` _followed by_ \\n
 
 A _string literal_ is a sequence of any Unicode characters enclosed within two
 `U+0022` (double-quote) characters, with the exception of `U+0022` itself,
@@ -162,13 +162,13 @@ following forms:
 
 #### Raw string literals
 
-> **<sup>Lexer</sup>**  
-> RAW_STRING_LITERAL :  
-> &nbsp;&nbsp; `r` RAW_STRING_CONTENT  
->  
-> RAW_STRING_CONTENT :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ _IsolatedCR_ )<sup>* (non-greedy)</sup> `"`  
-> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`  
+> **<sup>Lexer</sup>**\
+> RAW_STRING_LITERAL :\
+> &nbsp;&nbsp; `r` RAW_STRING_CONTENT
+>
+> RAW_STRING_CONTENT :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ _IsolatedCR_ )<sup>* (non-greedy)</sup> `"`\
+> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`
 
 Raw string literals do not process any escapes. They start with the character
 `U+0072` (`r`), followed by zero or more of the character `U+0023` (`#`) and a
@@ -199,16 +199,16 @@ r##"foo #"# bar"##;                // foo #"# bar
 
 #### Byte literals
 
-> **<sup>Lexer</sup>**  
-> BYTE_LITERAL :  
-> &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'`  
->  
-> ASCII_FOR_CHAR :  
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F), except_ `'`, `\`, \\n, \\r or \\t  
->  
-> BYTE_ESCAPE :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT  
-> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`  
+> **<sup>Lexer</sup>**\
+> BYTE_LITERAL :\
+> &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'`
+>
+> ASCII_FOR_CHAR :\
+> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F), except_ `'`, `\`, \\n, \\r or \\t
+>
+> BYTE_ESCAPE :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\
+> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`
 
 A _byte literal_ is a single ASCII character (in the `U+0000` to `U+007F`
 range) or a single _escape_ preceded by the characters `U+0062` (`b`) and
@@ -219,12 +219,12 @@ _number literal_.
 
 #### Byte string literals
 
-> **<sup>Lexer</sup>**  
-> BYTE_STRING_LITERAL :  
-> &nbsp;&nbsp; `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )<sup>\*</sup> `"`  
->  
-> ASCII_FOR_STRING :  
-> &nbsp;&nbsp; _any ASCII (i.e 0x00 to 0x7F), except_ `"`, `\` _and IsolatedCR_ 
+> **<sup>Lexer</sup>**\
+> BYTE_STRING_LITERAL :\
+> &nbsp;&nbsp; `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )<sup>\*</sup> `"`
+>
+> ASCII_FOR_STRING :\
+> &nbsp;&nbsp; _any ASCII (i.e 0x00 to 0x7F), except_ `"`, `\` _and IsolatedCR_
 
 A non-raw _byte string literal_ is a sequence of ASCII characters and _escapes_,
 preceded by the characters `U+0062` (`b`) and `U+0022` (double-quote), and
@@ -250,16 +250,16 @@ following forms:
 
 #### Raw byte string literals
 
-> **<sup>Lexer</sup>**  
-> RAW_BYTE_STRING_LITERAL :  
-> &nbsp;&nbsp; `br` RAW_BYTE_STRING_CONTENT  
->  
-> RAW_BYTE_STRING_CONTENT :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ASCII<sup>* (non-greedy)</sup> `"`  
-> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`  
->  
-> ASCII :  
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F)_  
+> **<sup>Lexer</sup>**\
+> RAW_BYTE_STRING_LITERAL :\
+> &nbsp;&nbsp; `br` RAW_BYTE_STRING_CONTENT
+>
+> RAW_BYTE_STRING_CONTENT :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `"` ASCII<sup>* (non-greedy)</sup> `"`\
+> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`
+>
+> ASCII :\
+> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F)_
 
 Raw byte string literals do not process any escapes. They start with the
 character `U+0062` (`b`), followed by `U+0072` (`r`), followed by zero or more
@@ -294,39 +294,39 @@ literal_. The grammar for recognizing the two kinds of literals is mixed.
 
 #### Integer literals
 
-> **<sup>Lexer</sup>**  
-> INTEGER_LITERAL :  
+> **<sup>Lexer</sup>**\
+> INTEGER_LITERAL :\
 > &nbsp;&nbsp; ( DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL )
 >              INTEGER_SUFFIX<sup>?</sup>
->  
-> DEC_LITERAL :  
-> &nbsp;&nbsp; DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>  
->  
-> TUPLE_INDEX :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `0`
-> &nbsp;&nbsp; | NON_ZERO_DEC_DIGIT DEC_DIGIT<sup>\*</sup>  
 >
-> BIN_LITERAL :  
-> &nbsp;&nbsp; `0b` (BIN_DIGIT|`_`)<sup>\*</sup> BIN_DIGIT (BIN_DIGIT|`_`)<sup>\*</sup>  
->  
-> OCT_LITERAL :  
-> &nbsp;&nbsp; `0o` (OCT_DIGIT|`_`)<sup>\*</sup> OCT_DIGIT (OCT_DIGIT|`_`)<sup>\*</sup>  
->  
-> HEX_LITERAL :  
-> &nbsp;&nbsp; `0x` (HEX_DIGIT|`_`)<sup>\*</sup> HEX_DIGIT (HEX_DIGIT|`_`)<sup>\*</sup>  
->  
-> BIN_DIGIT : [`0`-`1`]  
->  
-> OCT_DIGIT : [`0`-`7`]  
->  
-> DEC_DIGIT : [`0`-`9`]  
->  
-> NON_ZERO_DEC_DIGIT : [`1`-`9`]  
->  
-> HEX_DIGIT : [`0`-`9` `a`-`f` `A`-`F`]  
->  
-> INTEGER_SUFFIX :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `u8` | `u16` | `u32` | `u64` | `u128` | `usize`  
+> DEC_LITERAL :\
+> &nbsp;&nbsp; DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
+>
+> TUPLE_INDEX :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `0`
+> &nbsp;&nbsp; | NON_ZERO_DEC_DIGIT DEC_DIGIT<sup>\*</sup>
+>
+> BIN_LITERAL :\
+> &nbsp;&nbsp; `0b` (BIN_DIGIT|`_`)<sup>\*</sup> BIN_DIGIT (BIN_DIGIT|`_`)<sup>\*</sup>
+>
+> OCT_LITERAL :\
+> &nbsp;&nbsp; `0o` (OCT_DIGIT|`_`)<sup>\*</sup> OCT_DIGIT (OCT_DIGIT|`_`)<sup>\*</sup>
+>
+> HEX_LITERAL :\
+> &nbsp;&nbsp; `0x` (HEX_DIGIT|`_`)<sup>\*</sup> HEX_DIGIT (HEX_DIGIT|`_`)<sup>\*</sup>
+>
+> BIN_DIGIT : [`0`-`1`]
+>
+> OCT_DIGIT : [`0`-`7`]
+>
+> DEC_DIGIT : [`0`-`9`]
+>
+> NON_ZERO_DEC_DIGIT : [`1`-`9`]
+>
+> HEX_DIGIT : [`0`-`9` `a`-`f` `A`-`F`]
+>
+> INTEGER_SUFFIX :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `u8` | `u16` | `u32` | `u64` | `u128` | `usize`\
 > &nbsp;&nbsp; | `i8` | `i16` | `i32` | `i64` | `i128` | `isize`
 
 An _integer literal_ has one of four forms:
@@ -417,20 +417,20 @@ a single integer literal.
 
 #### Floating-point literals
 
-> **<sup>Lexer</sup>**  
-> FLOAT_LITERAL :  
+> **<sup>Lexer</sup>**\
+> FLOAT_LITERAL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL `.`
->   _(not immediately followed by `.`, `_` or an [identifier]_)  
-> &nbsp;&nbsp; | DEC_LITERAL FLOAT_EXPONENT  
-> &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL FLOAT_EXPONENT<sup>?</sup>  
+>   _(not immediately followed by `.`, `_` or an [identifier]_)\
+> &nbsp;&nbsp; | DEC_LITERAL FLOAT_EXPONENT\
+> &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL FLOAT_EXPONENT<sup>?</sup>\
 > &nbsp;&nbsp; | DEC_LITERAL (`.` DEC_LITERAL)<sup>?</sup>
->                    FLOAT_EXPONENT<sup>?</sup> FLOAT_SUFFIX  
->  
-> FLOAT_EXPONENT :  
+>                    FLOAT_EXPONENT<sup>?</sup> FLOAT_SUFFIX
+>
+> FLOAT_EXPONENT :\
 > &nbsp;&nbsp; (`e`|`E`) (`+`|`-`)?
->               (DEC_DIGIT|`_`)<sup>\*</sup> DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>   
->  
-> FLOAT_SUFFIX :  
+>               (DEC_DIGIT|`_`)<sup>\*</sup> DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
+>
+> FLOAT_SUFFIX :\
 > &nbsp;&nbsp; `f32` | `f64`
 
 A _floating-point literal_ has one of two forms:
@@ -478,21 +478,21 @@ The representation semantics of floating-point numbers are described in
 
 ### Boolean literals
 
-> **<sup>Lexer</sup>**  
-> BOOLEAN_LITERAL :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `true`  
-> &nbsp;&nbsp; | `false`  
+> **<sup>Lexer</sup>**\
+> BOOLEAN_LITERAL :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `true`\
+> &nbsp;&nbsp; | `false`
 
 The two values of the boolean type are written `true` and `false`.
 
 ## Lifetimes and loop labels
 
-> **<sup>Lexer</sup>**  
-> LIFETIME_TOKEN :  
-> &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER_OR_KEYWORD][identifier]  
-> &nbsp;&nbsp; | `'_`  
->  
-> LIFETIME_OR_LABEL :  
+> **<sup>Lexer</sup>**\
+> LIFETIME_TOKEN :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER_OR_KEYWORD][identifier]\
+> &nbsp;&nbsp; | `'_`
+>
+> LIFETIME_OR_LABEL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER][identifier]
 
 Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -1,25 +1,25 @@
 # Trait and lifetime bounds
 
-> **<sup>Syntax</sup>**  
-> _TypeParamBounds_ :  
-> &nbsp;&nbsp; _TypeParamBound_ ( `+` _TypeParamBound_ )<sup>\*</sup> `+`<sup>?</sup>  
->  
-> _TypeParamBound_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; _Lifetime_ | _TraitBound_  
->  
-> _TraitBound_ :  
+> **<sup>Syntax</sup>**\
+> _TypeParamBounds_ :\
+> &nbsp;&nbsp; _TypeParamBound_ ( `+` _TypeParamBound_ )<sup>\*</sup> `+`<sup>?</sup>
+>
+> _TypeParamBound_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; _Lifetime_ | _TraitBound_
+>
+> _TraitBound_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `?`<sup>?</sup>
-> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TraitPath_]  
+> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TraitPath_]\
 > &nbsp;&nbsp; | `(` `?`<sup>?</sup>
-> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TraitPath_] `)`  
->  
-> _LifetimeBounds_ :  
-> &nbsp;&nbsp; ( _Lifetime_ `+` )<sup>\*</sup> _Lifetime_<sup>?</sup>  
->  
-> _Lifetime_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]  
-> &nbsp;&nbsp; | `'static`  
-> &nbsp;&nbsp; | `'_`  
+> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TraitPath_] `)`
+>
+> _LifetimeBounds_ :\
+> &nbsp;&nbsp; ( _Lifetime_ `+` )<sup>\*</sup> _Lifetime_<sup>?</sup>
+>
+> _Lifetime_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]\
+> &nbsp;&nbsp; | `'static`\
+> &nbsp;&nbsp; | `'_`
 
 [Trait] and lifetime bounds provide a way for [generic items][generic] to
 restrict which types and lifetimes are used as their parameters. Bounds can be

--- a/src/types.md
+++ b/src/types.md
@@ -432,7 +432,7 @@ order to capture a single field:
 
 ```rust
 # use std::collections::HashSet;
-# 
+#
 struct SetVec {
     set: HashSet<u32>,
     vec: Vec<u32>
@@ -554,7 +554,7 @@ traits except the first trait must be auto traits, there may not be more than
 one lifetime, and opt-out bounds (e.g. `?sized`) are not allowed. Furthermore,
 paths to traits may be parenthesized.
 
-For example, given a trait `Trait`, the following are all trait objects: 
+For example, given a trait `Trait`, the following are all trait objects:
 
 * `Trait`
 * `dyn Trait`

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -1,13 +1,13 @@
 # Visibility and Privacy
 
-> **<sup>Syntax<sup>**  
-> _Visibility_ :  
-> &nbsp;&nbsp; &nbsp;&nbsp; EMPTY  
-> &nbsp;&nbsp; | `pub`  
-> &nbsp;&nbsp; | `pub` `(` `crate` `)`  
-> &nbsp;&nbsp; | `pub` `(` `in` _ModulePath_ `)`  
-> &nbsp;&nbsp; | `pub` `(` `in`<sup>?</sup> `self` `)`  
-> &nbsp;&nbsp; | `pub` `(` `in`<sup>?</sup> `super` `)`  
+> **<sup>Syntax<sup>**\
+> _Visibility_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; EMPTY\
+> &nbsp;&nbsp; | `pub`\
+> &nbsp;&nbsp; | `pub` `(` `crate` `)`\
+> &nbsp;&nbsp; | `pub` `(` `in` _ModulePath_ `)`\
+> &nbsp;&nbsp; | `pub` `(` `in`<sup>?</sup> `self` `)`\
+> &nbsp;&nbsp; | `pub` `(` `in`<sup>?</sup> `super` `)`
 
 These two terms are often used interchangeably, and what they are attempting to
 convey is the answer to the question "Can this item be used at this location?"
@@ -197,7 +197,7 @@ fn bar() {
     // This function is no longer visible since we're outside of `outer_mod`
     // Error! `outer_mod_visible_fn` is private
     //outer_mod::inner_mod::outer_mod_visible_fn();
-    
+
     outer_mod::foo();
 }
 


### PR DESCRIPTION
The only formatting change is to add breaks on the weak keywords in
`keywords.md`.