### PR TITLE
fix link to ManuallyDrop

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -90,4 +90,4 @@ variable or field from being dropped automatically.
 [Trait objects]: types.html#trait-objects
 [`std::ptr::drop_in_place`]: ../std/ptr/fn.drop_in_place.html
 [`std::mem::forget`]: ../std/mem/fn.forget.html
-[`std::mem::ManuallyDrop`]: ../std/mem/union.ManuallyDrop.html
+[`std::mem::ManuallyDrop`]: ../std/mem/struct.ManuallyDrop.html


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/52711 changes `ManuallyDrop` from a union to a struct, so the link needs to be updated.