### PR TITLE
Add impl trait and remove others from undocumented list

### DIFF
--- a/src/undocumented.md
+++ b/src/undocumented.md
@@ -11,7 +11,6 @@ to shrink!
   not for everything: e.g. coherence and orphan rules.
 - [Flexible target specification] - Some---but not all---flags are documented
   in [Conditional compilation]
-- Require parentheses for chained comparisons
 - [`dllimport`] - one element mentioned but not explained at [FFI attributes]
 - [define `crt_link`]
 - [define `unaligned_access`]

--- a/src/undocumented.md
+++ b/src/undocumented.md
@@ -9,24 +9,20 @@ to shrink!
 - [`libstd` facade]
 - [Trait reform] – some partial documentation exists (the use of `Self`), but
   not for everything: e.g. coherence and orphan rules.
-- [Attributes on `match` arms] – the underlying idea is documented in the
-  [Attributes] section, but the applicability to internal items is never
-  specified.
 - [Flexible target specification] - Some---but not all---flags are documented
   in [Conditional compilation]
-- [Require parentheses for chained comparisons]
+- Require parentheses for chained comparisons
 - [`dllimport`] - one element mentioned but not explained at [FFI attributes]
 - [define `crt_link`]
 - [define `unaligned_access`]
+- `impl Trait`
 
 [`libstd` facade]: https://github.com/rust-lang/rfcs/pull/40
 [Trait reform]: https://github.com/rust-lang/rfcs/pull/48
 [Attributes on `match` arms]: https://github.com/rust-lang/rfcs/pull/49
 [Flexible target specification]: https://github.com/rust-lang/rfcs/pull/131
 [Conditional compilation]: attributes.html#conditional-compilation
-[Unambiguous function call syntax]: https://github.com/rust-lang/rfcs/pull/132
 [Integer overflow not `unsafe`]: https://github.com/rust-lang/rfcs/pull/560
 [`dllimport`]: https://github.com/rust-lang/rfcs/pull/1717
 [FFI attributes]: attributes.html#ffi-attributes
 [define `crt_link`]: https://github.com/rust-lang/rfcs/pull/1721
-[define `unaligned_access`]: https://github.com/rust-lang/rfcs/pull/1725


### PR DESCRIPTION
About removals:

* Attributes on match arms was documented by me last time I looked at attributes.
* UFCS a.k.a. diambiguating function calls is documented on the call expression page.
* unaligned access appears to just be library things