### PR TITLE
Attributes on functions

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -331,7 +331,7 @@ pub mod m3 {
 }
 ```
 
-#### `must_use` Attribute
+#### `must_use`
 
 The `must_use` attribute can be used on user-defined composite types
 ([`struct`s][struct], [`enum`s][enum], and [`union`s][union]) and [functions].

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -112,7 +112,7 @@ let a = unsafe { an_unsafe_fn() };
 Block expressions allow [outer attributes] and [inner attributes] directly after
 the opening brace when the block expression is the outer expression of an
 [expression statement] or the final expression of another block expression. The
-attributes that have meaning on a block expression are [`cfg`], and [the lint
+attributes that have meaning on a block expression are [`cfg`] and [the lint
 check attributes].
 
 For example, this function returns `true` on unix platforms and `false` on other
@@ -136,6 +136,6 @@ fn is_unix_platform() -> bool {
 [outer attributes]: attributes.html
 [inner attributes]: attributes.html
 [expression statement]: statements.html#expression-statements
-[`cfg`]: attributes.html#conditional-compilation
+[`cfg`]: conditional-compilation.html
 [the lint check attributes]: attributes.html#lint-check-attributes
 [unsafe operations]: unsafety.html

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -209,6 +209,6 @@ meaning on match arms are [`cfg`], `cold`, and the [lint check attributes].
 [numeric types]: types.html#numeric-types
 [_InnerAttribute_]: attributes.html
 [_OuterAttribute_]: attributes.html
-[`cfg`]: attributes.html#conditional-compilation
+[`cfg`]: conditional-compilation.html
 [lint check attributes]: attributes.html#lint-check-attributes
 [range]: expressions/range-expr.html

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -115,11 +115,13 @@ As non-Rust calling conventions do not support unwinding, unwinding past the end
 of an extern function will cause the process to abort. In LLVM, this is
 implemented by executing an illegal instruction.
 
-## Function attributes
+## Attributes on functions
 
-Inner [attributes] on the function's block apply to the function item as a whole.
+Functions allow for [outer attributes][attributes] and for [inner
+attributes][attributes] where inner attributes are allowed on its [block]. 
 
-For example, this function will only be available while running tests.
+For example of an inner attribute on a function, this function will only be 
+available while running tests.
 
 ```
 fn test_only() {
@@ -130,6 +132,11 @@ fn test_only() {
 > Note: Except for lints, it is idiomatic to only use outer attributes on
 > function items.
 
+The attributes that have meaning on a function are [`cfg`], [`deprecated`],
+[`doc`], `export_name`, `link_section`, `no_mangle`, [the lint check
+attributes], [`must_use`], [the testing attributes], and [the optimization hint
+attributes].
+
 [external blocks]: items/external-blocks.html
 [path]: paths.html
 [block]: expressions/block-expr.html
@@ -138,3 +145,10 @@ fn test_only() {
 [*function item type*]: types.html#function-item-types
 [Trait]: items/traits.html
 [attributes]: attributes.html
+[`cfg`]: conditional-compilation.html
+[the lint check attributes]: attributes.html#lint-check-attributes
+[the testing attributes]: attributes.html#testing
+[the optimization hint attributes]: attributes.html#optimization-hints
+[`deprecated`]: attributes.html#deprecation
+[`doc`]: attributes.html#documentation
+[`must_use`]: attributes.html#must_use

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -117,10 +117,10 @@ implemented by executing an illegal instruction.
 
 ## Attributes on functions
 
-Functions allow for [outer attributes][attributes] and for [inner
-attributes][attributes] where inner attributes are allowed on its [block]. 
+[Outer attributes][attributes] are allowed on functions. [Inner
+attributes][attributes] are allowed directly after the `{` inside its [block].
 
-For example of an inner attribute on a function, this function will only be 
+This example shows an inner attribute on a function. The function will only be 
 available while running tests.
 
 ```

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -145,7 +145,7 @@ attributes].
 
 [trait]: items/traits.html
 [attributes]: attributes.html
-[`cfg`]: attributes.html#conditional-compilation
+[`cfg`]: conditional-compilation.html
 [`deprecated`]: attributes.html#deprecation
 [`doc`]: attributes.html#documentation
 [the lint check attributes]: attributes.html#lint-check-attributes

--- a/src/statements.md
+++ b/src/statements.md
@@ -104,5 +104,5 @@ statement are [`cfg`], and [the lint check attributes].
 [implementations]: items/implementations.html
 [variables]: variables.html
 [outer attributes]: attributes.html
-[`cfg`]: attributes.html#conditional-compilation
+[`cfg`]: conditional-compilation.html
 [the lint check attributes]: attributes.html#lint-check-attributes


### PR DESCRIPTION
This is blocked on #381 and #382 for correct links.

1. The main task of this PR is to show which attributes are allowed on functions.
2. I renamed the "`must_use` Attribute" section to `must_use` to match the "`derive`" section further on in the page.
3. Updated links to the `cfg` attribute to the new conditional compilation page. Probably should have done this when moving `cfg` to its own page. But doing it here where I'm adding a new link to it.