### PR TITLE
`derive` implements traits, not types

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -454,7 +454,7 @@ impl<T: PartialEq> PartialEq for Foo<T> {
 }
 ```
 
-You can implement `derive` for your own type through [procedural macros].
+You can implement `derive` for your own trait through [procedural macros].
 
 [Doc comments]: comments.html#doc-comments
 [The Rustdoc Book]: ../rustdoc/the-doc-attribute.html


### PR DESCRIPTION
It's a pretty small thing, and I don't have any examples of anyone being led astray, but it's technically incorrect to say that one would implement `derive` for a 'type'.

- - -

Note: Didn't intend to add in the final line's terminator at the end of the file—Github in-browser editor artifact. I can remove it if it's objectionable.