### PR TITLE
Fix lifetimes with raw identifiers.

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -7,8 +7,10 @@
 >
 > RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*Except `crate`, `extern`, `self`, `super`, `Self`*</sub>
 >
+> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub>
+>
 > IDENTIFIER :\
-> IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub> | RAW_IDENTIFIER
+> NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER
 
 An identifier is any nonempty ASCII string of the following form:
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -502,7 +502,7 @@ The two values of the boolean type are written `true` and `false`.
 > &nbsp;&nbsp; | `'_`
 >
 > LIFETIME_OR_LABEL :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER][identifier]
+> &nbsp;&nbsp; &nbsp;&nbsp; `'` [NON_KEYWORD_IDENTIFIER][identifier]
 
 Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any
 LIFETIME_TOKEN will be accepted by the lexer, and for example, can be used in


### PR DESCRIPTION
Lifetimes (and labels) don't support raw identifiers.