### PR TITLE
the originally -> originally

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -143,12 +143,12 @@ unnamed memory location is created initialized to that value and the expression
 evaluates to that location instead, except if promoted to `'static`. Promotion
 of a value expression to a `'static` slot occurs when the expression could be
 written in a constant, borrowed, and dereferencing that borrow where the
-expression was the originally written, without changing the runtime behavior.
-That is, the promoted expression can be evaluated at compile-time and the
-resulting value does not contain [interior mutability] or [destructors] (these
-properties are determined based on the value where possible, e.g. `&None`
-always has the type `&'static Option<_>`, as it contains nothing disallowed).
-Otherwise, the lifetime of temporary values is typically
+expression was originally written, without changing the runtime behavior. That
+is, the promoted expression can be evaluated at compile-time and the resulting
+value does not contain [interior mutability] or [destructors] (these properties
+are determined based on the value where possible, e.g. `&None` always has the
+type `&'static Option<_>`, as it contains nothing disallowed). Otherwise, the
+lifetime of temporary values is typically
 
 - the innermost enclosing statement; the tail expression of a block is
   considered part of the statement that encloses the block, or


### PR DESCRIPTION
Small typo fix.