### PR TITLE
Better link to repr attribute from structs page

### DIFF
--- a/src/items/structs.md
+++ b/src/items/structs.md
@@ -78,7 +78,7 @@ let c = [Cookie, Cookie {}, Cookie, Cookie {}];
 The precise memory layout of a struct is not specified. One can specify a
 particular layout using the [`repr` attribute].
 
-[`repr` attribute]: attributes.html#ffi-attributes
+[`repr` attribute]: type-layout.html#representations
 
 [_OuterAttribute_]: attributes.html
 [IDENTIFIER]: identifiers.html


### PR DESCRIPTION
Before it was linking to `attributes.html#ffi-attributes`, which links
to `type-layout.html#representations`. This saves a click for people
that want to go straight to the `repr` documentation.