### PR TITLE
Mention syntax ambiguity for eRFC 2947.

### DIFF
--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -44,7 +44,7 @@ assert_eq!(y, "Bigger");
 
 > **<sup>Syntax</sup>**\
 > _IfLetExpression_ :\
-> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Expression_]<sub>_except struct expression_</sub>
+> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 >              [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
@@ -111,6 +111,12 @@ match EXPR {
 }
 ```
 
+The expression cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
+Use of a lazy boolean operator is ambiguous with a planned feature change
+of the language (the implementation of if-let chains - see [eRFC 2947][_eRFCIfLetChain_]).
+
 [_Expression_]: expressions.html
 [_BlockExpression_]: expressions/block-expr.html
 [_Pattern_]: patterns.html
+[_LazyBooleanOperatorExpression_]: expressions/operator-expr.html#lazy-boolean-operators
+[_eRFCIfLetChain_]: https://github.com/rust-lang/rfcs/blob/master/text/2497-if-let-chains.md#rollout-plan-and-transitioning-to-rust-2018

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -114,6 +114,22 @@ match EXPR {
 The expression cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
 Use of a lazy boolean operator is ambiguous with a planned feature change
 of the language (the implementation of if-let chains - see [eRFC 2947][_eRFCIfLetChain_]).
+When lazy boolean operator expression is desired, this can be achieved
+by using parenthesis as below:
+
+```rust,ignore
+// Before...
+if let PAT = EXPR && EXPR { .. }
+
+// After...
+if let PAT = ( EXPR && EXPR ) { .. }
+
+// Before...
+if let PAT = EXPR || EXPR { .. }
+
+// After...
+if let PAT = ( EXPR || EXPR ) { .. }
+```
 
 [_Expression_]: expressions.html
 [_BlockExpression_]: expressions/block-expr.html


### PR DESCRIPTION
Part of rust-lang/rust#53668.

cc @centril