### PR TITLE
Add a missing link.

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -277,6 +277,7 @@ fn invoke4() {}
 [Function-like macros]: #function-like-procedural-macros
 [attribute]: attributes.html
 [attributes]: attributes.html
+[block]: expressions/block-expr.html
 [custom attributes]: attributes.html
 [crate type]: linkage.html
 [derive mode helper attributes]: #derive-mode-helper-attributes


### PR DESCRIPTION
The 3rd paragraph in [Derive mode macros](https://doc.rust-lang.org/nightly/reference/procedural-macros.html#derive-mode-macros) missed a link.