### PR TITLE
Remove the last remnants of the old grammar.

### DIFF
--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -9,7 +9,7 @@
 
 > **<sup>Lexer</sup>**\
 > UTF8BOM : `\uFEFF`\
-> SHEBANG : `#!` ~[`[` `\n`] ~`\n`<sup>*</sup>
+> SHEBANG : `#!` ~[`[` `\n`] ~`\n`<sup>\*</sup>
 
 
 > Note: Although Rust, like any other language, can be implemented by an
@@ -42,12 +42,12 @@ extension `.rs`.
 
 A Rust source file describes a module, the name and location of which &mdash;
 in the module tree of the current crate &mdash; are defined from outside the
-source file: either by an explicit [`mod` item][module] in a referencing
+source file: either by an explicit [_Module_][module] item in a referencing
 source file, or by the name of the crate itself. Every source file is a
 module, but not every module needs its own source file: [module
 definitions][module] can be nested within one file.
 
-Each source file contains a sequence of zero or more `item` definitions, and
+Each source file contains a sequence of zero or more [_Item_] definitions, and
 may optionally begin with any number of [attributes]
 that apply to the containing module, most of which influence the behavior of
 the compiler. The anonymous crate module can have additional attributes that

--- a/src/expressions/closure-expr.md
+++ b/src/expressions/closure-expr.md
@@ -3,8 +3,14 @@
 > **<sup>Syntax</sup>**\
 > _ClosureExpression_ :\
 > &nbsp;&nbsp; `move`<sup>?</sup>\
-> &nbsp;&nbsp; ( `||` | `|` [_FunctionParameters_]<sup>?</sup> `|` )\
+> &nbsp;&nbsp; ( `||` | `|` _ClosureParameters_<sup>?</sup> `|` )\
 > &nbsp;&nbsp; ([_Expression_] | `->` [_TypeNoBounds_]&nbsp;[_BlockExpression_])
+>
+> _ClosureParameters_ :\
+> &nbsp;&nbsp; _ClosureParam_ (`,` _ClosureParam_)<sup>\*</sup> `,`<sup>?</sup>
+>
+> _ClosureParam_ :\
+> &nbsp;&nbsp; [_Pattern_]&nbsp;( `:` [_Type_] )<sup>?</sup>
 
 A _closure expression_ defines a closure and denotes it as a value, in a single
 expression. A closure expression is a pipe-symbol-delimited (`|`) list of
@@ -14,11 +20,11 @@ type, the expression used for the body of the closure must be a normal
 [block]. A closure expression also may begin with the
 `move` keyword before the initial `|`.
 
-A closure expression denotes a function that maps a list of parameters
-(`ident_list`) onto the expression that follows the `ident_list`. The patterns
-in the `ident_list` are the parameters to the closure. If a parameter's types
-is not specified, then the compiler infers it from context. Each closure
-expression has a unique anonymous type.
+A closure expression denotes a function that maps a list of parameters onto
+the expression that follows the parameters. Just like a [`let` binding], the
+parameters are irrefutable [patterns], whose type annotation is optional and
+will be inferred from context if not given. Each closure expression has a
+unique, anonymous type.
 
 Closure expressions are most useful when passing functions as arguments to other
 functions, as an abbreviation for defining and capturing a separate function.
@@ -69,3 +75,6 @@ ten_times(move |j| println!("{}, {}", word, j));
 [_BlockExpression_]: expressions/block-expr.html
 [_TypeNoBounds_]: types.html#type-expressions
 [_FunctionParameters_]: items/functions.html
+[_Pattern_]: patterns.html
+[_Type_]: types.html#type-expressions
+[`let` binding]: statements.html#let-statements

--- a/src/input-format.md
+++ b/src/input-format.md
@@ -1,10 +1,3 @@
 # Input format
 
 Rust input is interpreted as a sequence of Unicode code points encoded in UTF-8.
-Most Rust grammar rules are defined in terms of printable ASCII-range
-code points, but a small number are defined in terms of Unicode properties or
-explicit code point lists. [^inputformat]
-
-[^inputformat]: Substitute definitions for the special Unicode productions are
-  provided to the grammar verifier, restricted to ASCII range, when verifying the
-  grammar in this document.

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -9,8 +9,6 @@ provides three kinds of material:
   - Appendix chapters providing rationale and references to languages that
     influenced the design.
 
-> **Note**: You may also be interested in the [grammar].
-
 <div class="warning">
 
 Warning: This book is incomplete. Documenting everything takes a while. See
@@ -120,6 +118,8 @@ information. These conventions are documented here.
   > &nbsp;&nbsp; &nbsp;&nbsp; `~` [_Expression_]\
   > &nbsp;&nbsp; | `box` [_Expression_]
 
+  See [Notation] for more detail.
+
 ## Contributing
 
 We welcome contributions of all kinds.
@@ -133,7 +133,6 @@ attention to making those sections the best that they can be.
 
 [book]: ../book/index.html
 [standard library]: ../std/index.html
-[grammar]: ../grammar.html
 [the Rust Reference repository]: https://github.com/rust-lang-nursery/reference/
 [big issue]: https://github.com/rust-lang-nursery/reference/issues/9
 [Unstable Book]: https://doc.rust-lang.org/nightly/unstable-book/
@@ -145,3 +144,4 @@ attention to making those sections the best that they can be.
 [linkage]: linkage.html
 [rustc book]: ../rustc/index.html
 [undocumented]: undocumented.html
+[Notation]: notation.html

--- a/src/notation.md
+++ b/src/notation.md
@@ -1,12 +1,25 @@
 # Notation
 
-## Unicode productions
+## Grammar
 
-A few productions in Rust's grammar permit Unicode code points outside the
-ASCII range. We define these productions in terms of character properties
-specified in the Unicode standard, rather than in terms of ASCII-range code
-points. The grammar has a [Special Unicode Productions] section that lists these
-productions.
+The following notations are used by the *Lexer* and *Syntax* grammar snippets:
+
+| Notation          | Examples                      | Meaning                                   |
+|-------------------|-------------------------------|-------------------------------------------|
+| CAPITAL           | KW_IF, INTEGER_LITERAL        | A token produced by the lexer             |
+| _ItalicCamelCase_ | _LetStatement_, _Item_        | A syntactical production                  |
+| `string`          | `x`, `while`, `*`             | The exact character(s)                    |
+| \\x               | \\n, \\r, \\t, \\0            | The character represented by this escape  |
+| x<sup>?</sup>     | `pub`<sup>?</sup>             | An optional item                          |
+| x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
+| x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
+| x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x                   |
+| \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
+| [ ]               | [`b` `B`]                     | Any of the characters listed              |
+| [ - ]             | [`a`-`z`]                     | Any of the characters in the range        |
+| ~[ ]              | ~[`b` `B`]                    | Any characters, except those listed       |
+| ~`string`         | ~`\n`, ~`*/`                  | Any characters, except this sequence      |
+| ( )               | (`,` _Parameter_)<sup>?</sup> | Groups items                              |
 
 ## String table productions
 
@@ -22,7 +35,6 @@ When such a string in `monospace` font occurs inside the grammar,
 it is an implicit reference to a single member of such a string table
 production. See [tokens] for more information.
 
-[Special Unicode Productions]: ../grammar.html#special-unicode-productions
 [binary operators]: expressions/operator-expr.html#arithmetic-and-logical-binary-operators
 [keywords]: keywords.html
 [tokens]: tokens.html


### PR DESCRIPTION
Now that the reference includes the complete grammar, I think the last remaining references to the old grammar can be removed. This includes a few different changes (I can split these up if you'd like):

- Remove some references to the old grammar's rule names.
- Remove the link to the old grammar.
- Fix a bug with the _ClosureExpression_ rule which didn't correctly allow for untyped parameters. Also rewrote some of the closure text when removing the old rule names.
- Remove some of the grammar descriptions that only applied to the old grammar.
- Added a brief description of the notation based on some unfinished work by brauliobz.

