### PR TITLE
Fix typo in "const functions" section

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -150,7 +150,7 @@ If a const function is called outside a [const context], it is indistinguishable
 from any other function. You can freely do anything with a const function that
 you can do with a regular function.
 
-Const functions have various restrictions to make sure that they can't be
+Const functions have various restrictions to make sure that they can be
 evaluated at compile-time. It is, for example, not possible to write a random
 number generator as a const function. Calling a const function at compile-time
 will always yield the same result as calling it at runtime, even when called


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/reference/issues/476