### PR TITLE
Use mdbook release binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: rust
 rust:
   - nightly
 
-before_script:
-  - (cargo install mdbook --version =0.1.7)
+install:
+  - travis_retry curl -Lf https://github.com/rust-lang-nursery/mdBook/releases/download/v0.1.7/mdbook-v0.1.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=$HOME/.cargo/bin
 
-script: 
+script:
   - export PATH=$PATH:/home/travis/.cargo/bin && mdbook test
   - cd stable-check && cargo run -- ../src


### PR DESCRIPTION
Travis has pretty good support for caching rust builds now by store the .cargo directory.  This would enable this build to rebuild mdbook every time.

From [my test], it looks like the average build time will go from ~10 minutes to ~1 minute.

The one potential downside to this is mdbook won't be rebuilt with new nightly versions of Rust.  Presumably this doesn't matter though since the version of mdbook is pinned, and upgrading it would require running one build with `cargo install --force --version =<new-version>`, and then removing the `--force` again (otherwise it would always rebuild and thus remove the point of caching it). It doesn't seem like the version of mdbook is getting updated regularly though so this seems like it shouldn't be too big of a burden.

[my test]: https://travis-ci.com/RadicalZephyr/reference/builds/95976952