### PR TITLE
"head expression" => "scrutinee expression"

### DIFF
--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -72,10 +72,10 @@ while i < 10 {
 
 A `while let` loop is semantically similar to a `while` loop but in place of a
 condition expression it expects the keyword `let` followed by a refutable
-pattern, an `=`, an expression and a block expression. If the value of the expression on
-the right hand side of the `=` matches the pattern, the loop body block executes then
-control returns to the pattern matching statement. Otherwise, the while
-expression completes.
+pattern, an `=`, a scrutinee expression and a block expression. If the value of
+the expression on the right hand side of the `=` matches the pattern, the loop
+body block executes then control returns to the pattern matching statement.
+Otherwise, the while expression completes.
 
 ```rust
 let mut x = vec![1, 2, 3];

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -70,9 +70,11 @@ while i < 10 {
 > &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Expression_]<sub>except struct expression</sub>
 >              [_BlockExpression_]
 
+[scrutinee]: glossary.html#scrutinee
+
 A `while let` loop is semantically similar to a `while` loop but in place of a
 condition expression it expects the keyword `let` followed by a refutable
-pattern, an `=`, a scrutinee expression and a block expression. If the value of
+pattern, an `=`, a [scrutinee] expression and a block expression. If the value of
 the expression on the right hand side of the `=` matches the pattern, the loop
 body block executes then control returns to the pattern matching statement.
 Otherwise, the while expression completes.

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -70,8 +70,6 @@ while i < 10 {
 > &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Expression_]<sub>except struct expression</sub>
 >              [_BlockExpression_]
 
-[scrutinee]: glossary.html#scrutinee
-
 A `while let` loop is semantically similar to a `while` loop but in place of a
 condition expression it expects the keyword `let` followed by a refutable
 pattern, an `=`, a [scrutinee] expression and a block expression. If the value of
@@ -276,3 +274,5 @@ expression `()`.
 [_Pattern_]: patterns.html
 
 [LIFETIME_OR_LABEL]: tokens.html#lifetimes-and-loop-labels
+
+[scrutinee]: glossary.html#scrutinee

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -25,21 +25,21 @@
 
 A *`match` expression* branches on a pattern. The exact form of matching that
 occurs depends on the [pattern]. A `match`
-expression has a *head expression*, which is the value to compare to the
-patterns. The head expression and the patterns must have the same type.
+expression has a *scrutinee expression*, which is the value to compare to the
+patterns. The scrutinee expression and the patterns must have the same type.
 
-A `match` behaves differently depending on whether or not the head expression
-is a [place expression or value expression][place expression].
-If the head expression is a [value expression], it is first evaluated into a
-temporary location, and the resulting value is sequentially compared to the
+A `match` behaves differently depending on whether or not the scrutinee
+expression is a [place expression or value expression][place expression].
+If the scrutinee expression is a [value expression], it is first evaluated into
+a temporary location, and the resulting value is sequentially compared to the
 patterns in the arms until a match is found. The first arm with a matching
 pattern is chosen as the branch target of the `match`, any variables bound by
 the pattern are assigned to local variables in the arm's block, and control
 enters the block.
 
-When the head expression is a [place expression], the match does not allocate a
-temporary location; however, a by-value binding may copy or move from the
-memory location.
+When the scrutinee expression is a [place expression], the match does not
+allocate a temporary location; however, a by-value binding may copy or move
+from the memory location.
 When possible, it is preferable to match on place expressions, as the lifetime
 of these matches inherits the lifetime of the place expression rather than being
 restricted to the inside of the match.

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -23,9 +23,11 @@
 > _MatchArmGuard_ :\
 > &nbsp;&nbsp; `if` [_Expression_]
 
+[scrutinee]: glossary.html#scrutinee
+
 A *`match` expression* branches on a pattern. The exact form of matching that
 occurs depends on the [pattern]. A `match`
-expression has a *scrutinee expression*, which is the value to compare to the
+expression has a *[scrutinee] expression*, which is the value to compare to the
 patterns. The scrutinee expression and the patterns must have the same type.
 
 A `match` behaves differently depending on whether or not the scrutinee

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -23,8 +23,6 @@
 > _MatchArmGuard_ :\
 > &nbsp;&nbsp; `if` [_Expression_]
 
-[scrutinee]: glossary.html#scrutinee
-
 A *`match` expression* branches on a pattern. The exact form of matching that
 occurs depends on the [pattern]. A `match`
 expression has a *[scrutinee] expression*, which is the value to compare to the
@@ -146,3 +144,4 @@ expressions].
 [Range Pattern]: patterns.html#range-patterns
 [attributes on block expressions]: expressions/block-expr.html#attributes-on-block-expressions
 [binding mode]: patterns.html#binding-modes
+[scrutinee]: glossary.html#scrutinee

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -71,8 +71,6 @@ let base = Point3d {x: 1, y: 2, z: 3};
 Point3d {y: 0, z: 10, .. base};
 ```
 
-[scrutinee]: glossary.html#scrutinee
-
 Struct expressions with curly braces can't be used directly in a [loop] or [if]
 expression's head, or in the [scrutinee] of an [if let] or [match] expression.
 However, struct expressions can be in used in these situations if they are
@@ -153,3 +151,4 @@ expressions].
 [struct]: items/structs.html
 [union]: items/unions.html
 [visible]: visibility-and-privacy.html
+[scrutinee]: glossary.html#scrutinee

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -71,10 +71,10 @@ let base = Point3d {x: 1, y: 2, z: 3};
 Point3d {y: 0, z: 10, .. base};
 ```
 
-Struct expressions with curly braces can't be used directly in the head of a [loop] or an
-[if], [if let] or [match] expression. However, struct expressions can be in used in these
-situations if they are within another expression, for example inside
-[parentheses].
+Struct expressions with curly braces can't be used directly in a [loop] or [if]
+expression's head, or in the scrutinee of a [if let] or [match] expression.
+However, struct expressions can be in used in these situations if they are
+within another expression, for example inside [parentheses].
 
 The field names can be decimal integer values to specify indices for constructing tuple
 structs. This can be used with base structs to fill out the remaining indices not

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -71,8 +71,10 @@ let base = Point3d {x: 1, y: 2, z: 3};
 Point3d {y: 0, z: 10, .. base};
 ```
 
+[scrutinee]: glossary.html#scrutinee
+
 Struct expressions with curly braces can't be used directly in a [loop] or [if]
-expression's head, or in the scrutinee of a [if let] or [match] expression.
+expression's head, or in the [scrutinee] of an [if let] or [match] expression.
 However, struct expressions can be in used in these situations if they are
 within another expression, for example inside [parentheses].
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -80,6 +80,12 @@ Types that can be referred to by a path directly. Specifically [enums],
 Prelude, or The Rust Prelude, is a small collection of items - mostly traits - that are
 imported into every module of every crate. The traits in the prelude are pervasive.
 
+### Scrutinee
+
+A scrutinee is the expression that is matched on in `match` expressions and
+similar pattern matching constructs. For example, in `match x { A => 1, B => 2 }`,
+the expression `x` is the scrutinee.
+
 ### Size
 
 The size of a value has two definitions.

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -67,9 +67,11 @@ Patterns are used in:
 
 ## Destructuring
 
+[scrutinee]: glossary.html#scrutinee
+
 Patterns can be used to *destructure* [structs], [enums], and [tuples].
 Destructuring breaks up a value into its component pieces. The syntax used is
-almost the same as when creating such values. In a pattern whose scrutinee
+almost the same as when creating such values. In a pattern whose [scrutinee]
 expression has a `struct`, `enum` or `tuple` type, a placeholder (`_`) stands
 in for a *single* data field, whereas a wildcard `..` stands in for *all* the
 remaining fields of a particular variant. When destructuring a data structure

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -69,7 +69,7 @@ Patterns are used in:
 
 Patterns can be used to *destructure* [structs], [enums], and [tuples].
 Destructuring breaks up a value into its component pieces. The syntax used is
-almost the same as when creating such values. In a pattern whose head
+almost the same as when creating such values. In a pattern whose scrutinee
 expression has a `struct`, `enum` or `tuple` type, a placeholder (`_`) stands
 in for a *single* data field, whereas a wildcard `..` stands in for *all* the
 remaining fields of a particular variant. When destructuring a data structure

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -67,8 +67,6 @@ Patterns are used in:
 
 ## Destructuring
 
-[scrutinee]: glossary.html#scrutinee
-
 Patterns can be used to *destructure* [structs], [enums], and [tuples].
 Destructuring breaks up a value into its component pieces. The syntax used is
 almost the same as when creating such values. In a pattern whose [scrutinee]
@@ -678,3 +676,4 @@ refer to refutable constants or enum variants for enums with multiple variants.
 [literals]: expressions/literal-expr.html
 [structs]: items/structs.html
 [tuples]: types/tuple.html
+[scrutinee]: glossary.html#scrutinee


### PR DESCRIPTION
This PR renames *"__head__ expression"* wrt. `match` and such to *"__scrutinee__ expression"* as is typical in various languages with pattern matching (e.g. [Haskell](https://downloads.haskell.org/~ghc/7.6.2/docs/html/users_guide/informal-semantics.html), [OCaml](https://caml.inria.fr/pub/docs/manual-ocaml/extn.html#sec252), [Idris](https://www.idris-lang.org/idris-0-9-11-released/), [Agda](https://media.readthedocs.org/pdf/agda/v2.5.3/agda.pdf), [Scala](https://issues.scala-lang.org/browse/SI-7171), and [ML](https://samth.github.io/match-ifl-full.pdf)).