### PR TITLE
Fix some broken links.

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -9,7 +9,7 @@ can be evaluated at compile-time.
 Certain forms of expressions, called constant expressions, can be evaluated at
 compile time. In [const contexts](#const-context), these are the only allowed
 expressions, and are always evaluated at compile time. In other places, such as
-[let statement]s, constant expressions *may*
+[let statements], constant expressions *may*
 be, but are not guaranteed to be, evaluated at compile time. Behaviors such as
 out of bounds [array indexing] or [overflow] are compiler errors if the value
 must be evaluated at compile time (i.e. in const contexts). Otherwise, these
@@ -20,19 +20,19 @@ also constant expressions and do not cause any [`Drop::drop`][destructors] calls
 to be ran.
 
 * [Literals].
-* [Paths] to [functions](items/functions.html) and constants.
+* [Paths] to [functions] and constants.
   Recursively defining constants is not allowed.
 * [Tuple expressions].
 * [Array expressions].
 * [Struct] expressions.
 * [Enum variant] expressions.
 * [Block expressions], including `unsafe` blocks.
-    * [let statement]s and thus irrefutable [patterns], with the caveat that until `if` and `match`
+    * [let statements] and thus irrefutable [patterns], with the caveat that until `if` and `match`
     are implemented, one cannot use both short circuiting operators (`&&` and `||`) and let
     statements within the same constant.
-    * [assignment expressions](operator-expr.html#assignment-expressions)
-    * [assignment operator expressions](operator-expr.html#compound-assignment-expressions)
-    * [expression statements](statements.html#expression-statements)
+    * [assignment expressions]
+    * [assignment operator expressions]
+    * [expression statements]
 * [Field] expressions.
 * Index expressions, [array indexing] or [slice] with a `usize`.
 * [Range expressions].
@@ -57,34 +57,38 @@ A _const context_ is one of the following:
   * [statics]
   * [enum discriminants]
 
-[array type length expressions]: types/array.html
-[enum discriminants]: items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
-[constants]: items/constant-items.html
-[statics]: items/static-items.html
-[expressions]: expressions.html
-[array indexing]:       expressions/array-expr.html#array-and-slice-indexing-expressions
-[overflow]:             expressions/operator-expr.html#overflow
-[destructors]:          destructors.html
-[literals]:             expressions/literal-expr.html
-[paths]:                expressions/path-expr.html
-[tuple expressions]:    expressions/tuple-expr.html
-[array expressions]:    expressions/array-expr.html
-[struct]:               expressions/struct-expr.html
-[enum variant]:         expressions/enum-variant-expr.html
-[block expressions]:    expressions/block-expr.html
-[field]:                expressions/field-expr.html
-[array indexing]:       expressions/array-expr.html#array-and-slice-indexing-expressions
-[slice]:                types/slice.html
-[range expressions]:    expressions/range-expr.html
-[closure expressions]:  expressions/closure-expr.html
-[negation]:             expressions/operator-expr.html#negation-operators
 [arithmetic, logical]:  expressions/operator-expr.html#arithmetic-and-logical-binary-operators
-[comparison]:           expressions/operator-expr.html#comparison-operators
-[lazy boolean]:         expressions/operator-expr.html#lazy-boolean-operators
+[array expressions]:    expressions/array-expr.html
+[array indexing]:       expressions/array-expr.html#array-and-slice-indexing-expressions
+[array indexing]:       expressions/array-expr.html#array-and-slice-indexing-expressions
+[array type length expressions]: types/array.html
+[assignment expressions]: expressions/operator-expr.html#assignment-expressions
+[assignment operator expressions]: expressions/operator-expr.html#compound-assignment-expressions
+[block expressions]:    expressions/block-expr.html
 [borrow]:               expressions/operator-expr.html#borrow-operators
-[interior mutability]:  interior-mutability.html
-[dereference operator]: expressions/operator-expr.html#the-dereference-operator
-[grouped]:              expressions/grouped-expr.html
 [cast]:                 expressions/operator-expr.html#type-cast-expressions
-[let statement]: statements.html#let-statements
-[patterns]: patterns.html
+[closure expressions]:  expressions/closure-expr.html
+[comparison]:           expressions/operator-expr.html#comparison-operators
+[constants]:            items/constant-items.html
+[dereference operator]: expressions/operator-expr.html#the-dereference-operator
+[destructors]:          destructors.html
+[enum discriminants]:   items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
+[enum variant]:         expressions/enum-variant-expr.html
+[expression statements]: statements.html#expression-statements
+[expressions]:          expressions.html
+[field]:                expressions/field-expr.html
+[functions]:            items/functions.html
+[grouped]:              expressions/grouped-expr.html
+[interior mutability]:  interior-mutability.html
+[lazy boolean]:         expressions/operator-expr.html#lazy-boolean-operators
+[let statements]:       statements.html#let-statements
+[literals]:             expressions/literal-expr.html
+[negation]:             expressions/operator-expr.html#negation-operators
+[overflow]:             expressions/operator-expr.html#overflow
+[paths]:                expressions/path-expr.html
+[patterns]:             patterns.html
+[range expressions]:    expressions/range-expr.html
+[slice]:                types/slice.html
+[statics]:              items/static-items.html
+[struct]:               expressions/struct-expr.html
+[tuple expressions]:    expressions/tuple-expr.html


### PR DESCRIPTION
The links to operator-expr.html were broken. Also a little bit of cleanup
(mainly just sorting the link list).