### PR TITLE
Add linkchecker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
 
 script:
   - export PATH=$PATH:/home/travis/.cargo/bin && mdbook test
-  - cd stable-check && cargo run -- ../src
+  - (cd stable-check && cargo run -- ../src)
+  - tests/linkcheck.sh

--- a/src/items/unions.md
+++ b/src/items/unions.md
@@ -152,4 +152,4 @@ checking, etc etc etc).
 [_Generics_]: items/generics.html
 [_WhereClause_]: items/generics.html#where-clauses
 [_StructFields_]: items/structs.html
-[`transmute`]: ../../std/mem/fn.transmute.html
+[`transmute`]: ../std/mem/fn.transmute.html

--- a/tests/linkcheck.sh
+++ b/tests/linkcheck.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -f book.toml ]
+then
+    echo "Run command in root directory with book.toml"
+    exit 1
+fi
+
+rm -rf tests/linkcheck tests/linkchecker
+
+mkdir tests/linkchecker
+curl -o tests/linkchecker/Cargo.toml https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/Cargo.toml
+curl -o tests/linkchecker/main.rs https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/main.rs
+
+mdbook build
+
+cp -R $(rustc --print sysroot)/share/doc/rust/html tests/linkcheck
+rm -rf tests/linkcheck/reference
+cp -R book tests/linkcheck/reference
+
+cargo run --manifest-path=tests/linkchecker/Cargo.toml -- tests/linkcheck/reference
+
+rm -rf tests/linkcheck tests/linkchecker
+echo "Linkcheck completed successfully!"


### PR DESCRIPTION
This is a little gumby, but it works.

It:
- Downloads linkchecker from rust-lang/rust.
- Copies the HTML pages from nightly rustup, which should be a close reflection of how they look on doc.rust-lang.org.
- Build and copies the reference.
- Runs the linkchecker.
