### PR TITLE
Remove target_has_atomic.

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -153,20 +153,6 @@ to `"64"` for targets with 64-bit pointers.
 
 <!-- Are there targets that have a different bit number? --> 
 
-### `target_has_atomic`
-
-Key-value option set for each integer size on which the target can perform
-atomic operations.
-
-Possible values:
-
-* `"8"`
-* `"16"`
-* `"32"`
-* `"64"`
-* `"128"`
-* `"ptr"`
-
 ### `target_vendor`
 
 Key-value option set once with the vendor of the target.


### PR DESCRIPTION
`target_has_atomic` is not stable, and it's not clear to me if it ever will be. See https://github.com/rust-lang/rust/issues/56753 for more context.