### PR TITLE
Fix copy-paste error in procedural-macros.md

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -262,8 +262,8 @@ fn invoke3() {}
 // Example:
 #[show_streams { delimiters }]
 fn invoke4() {}
-// out: "delimiters"
-// out: "fn invoke4() {}"
+// out: attr: "delimiters"
+// out: item: "fn invoke4() {}"
 ```
 
 [`TokenStream`]: ../proc_macro/struct.TokenStream.html


### PR DESCRIPTION
Previously:

```rust
fn invoke1() {}
// out: attr: ""
// out: item: "fn invoke1() { }"

fn invoke2() {}
// out: attr: "bar"
// out: item: "fn invoke2() {}"

fn invoke3() {}
// out: attr: "multiple => tokens"
// out: item: "fn invoke3() {}"

fn invoke4() {}
// out: "delimiters"
// out: "fn invoke4() {}"
```

Added missing `attr` and `item`