### PR TITLE
Fix example code of derive macro

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -173,7 +173,7 @@ For example, the following derive macro defines a helper attribute
 
 #[proc_macro_derive(HelperAttr, attributes(helper))]
 pub fn derive_helper_attr(_item: TokenStream) -> TokenStream {
-    TokenStream::new();
+    TokenStream::new()
 }
 ```
 


### PR DESCRIPTION
There is an example in `procedural-macros.md` that doesn’t compile:
```
   Compiling proctest v0.1.0 (/nowhere/proctest)
error[E0308]: mismatched types
  --> src/lib.rs:42:50
   |
42 | pub fn derive_helper_attr(_item: TokenStream) -> TokenStream {
   |        ------------------                        ^^^^^^^^^^^ expected struct `proc_macro::TokenStream`, found ()
   |        |
   |        this function's body doesn't return
43 |     TokenStream::new();
   |                       - help: consider removing this semicolon
   |
   = note: expected type `proc_macro::TokenStream`
              found type `()`
```
This PR fixes the example so that it compiles.