### PR TITLE
Bitrig support has been removed

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -123,7 +123,6 @@ Example values:
 * `"android"`
 * `"freebsd"`
 * `"dragonfly"`
-* `"bitrig"`
 * `"openbsd"`
 * `"netbsd"`
 


### PR DESCRIPTION
Bitrig support has been removed (by me) in https://github.com/rust-lang/rust/pull/60775