### PR TITLE
Remove extra parenthesis

### DIFF
--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -42,7 +42,11 @@ to set the limit based on the number of type substitutions.
 
 > Note: The default in `rustc` is 1048576.
 
-```rust,compile_fail
+<!-- This code should fail to compile. Unfortunately rustdoc's `compile_fail`
+     stops after analysis phase, and this error is generated after that. So
+     this needs to be `ignore` for now. -->
+
+```rust,compile_fail,ignore
 #![type_length_limit = "8"]
 
 fn f<T>(x: T) {}

--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -50,7 +50,7 @@ fn f<T>(x: T) {}
 // This fails to compile because monomorphizing to
 // `f::<(i32, i32, i32, i32, i32, i32, i32, i32, i32)>>` requires more
 // than 8 type elements.
-f(((1, 2, 3, 4, 5, 6, 7, 8, 9));
+f((1, 2, 3, 4, 5, 6, 7, 8, 9));
 ```
 
 [_MetaNameValueStr_]: attributes.html#meta-item-attribute-syntax


### PR DESCRIPTION
There was an extra left parenthesis on the demo code for the `type_length_limit` attribute.
The code snippet isn't supposed to compile but produced the wrong error.

Edit: The snippet now _compiles_ when it isn't supposed to; I think we should open a separate issue?