### PR TITLE
Fix a type in the modules section: functions => modules

### DIFF
--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -135,7 +135,7 @@ Modules, like all items, accept outer attributes. They also accept inner
 attributes: either after `{` for a module with a body, or at the beginning of the
 source file, after the optional BOM and shebang.
 
-The built-in attributes that have meaning on a function are [`cfg`],
+The built-in attributes that have meaning on a module are [`cfg`],
 [`deprecated`], [`doc`], [the lint check attributes], `path`, and
 `no_implicit_prelude`. Modules also accept macro attributes.
 


### PR DESCRIPTION
The last paragraph in the modules section talks about attributes on modules.  It then says, "The built-in attributes that have meaning on a function are ...", and lists attributes such as `#[path]` that work on modules.

This changes it to "The built-in attributes that have meaning on a module are ..."
