### PR TITLE
Update partially initialized values in drop documentation.

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -63,11 +63,15 @@ loop {
     moved = ShowOnDrop("Drops when moved");
     // drops now, but is then uninitialized
     moved;
+
     // Uninitialized does not drop.
     let uninitialized: ShowOnDrop;
-    // Only first element drops
-    let mut partially_initialized = (ShowOnDrop("one"), ShowOnDrop("two"));
-    core::mem::forget(partially_initialized.1);
+
+    // After a partial move, only the remaining fields are dropped.
+    let mut partial_move = (ShowOnDrop("first"), ShowOnDrop("forgotten"));
+    // Perform a partial move, leaving only `partial_move.0` initialized.
+    core::mem::forget(partial_move.1);
+    // When partial_move's scope ends, only the first field is dropped.
 }
 ```
 

--- a/src/destructors.md
+++ b/src/destructors.md
@@ -63,10 +63,11 @@ loop {
     moved = ShowOnDrop("Drops when moved");
     // drops now, but is then uninitialized
     moved;
+    // Uninitialized does not drop.
     let uninitialized: ShowOnDrop;
     // Only first element drops
-    let mut partially_initialized: (ShowOnDrop, ShowOnDrop);
-    partially_initialized.0 = ShowOnDrop("Partial tuple first");
+    let mut partially_initialized = (ShowOnDrop("one"), ShowOnDrop("two"));
+    core::mem::forget(partially_initialized.1);
 }
 ```
 


### PR DESCRIPTION
As part of rust-lang/rust#63230, it does not appear to be possible to create a partially initialized value.

cc @RalfJung @tmandry  Please correct me if I'm wrong, I am unfamiliar with this. I was planning to do an update today, but can't with breakage.