### PR TITLE
Correct errors in the reference of extern functions definitions and declarations

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -88,7 +88,7 @@ pub fn name_in_rust() { }
 [_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`static` items]: items/static-items.md
 [attribute]: attributes.md
-[extern functions]: items/functions.md#extern-functions
+[extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md
 [function]: items/functions.md
 [item]: items.md

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -29,8 +29,12 @@
 > _NamedFunctionParametersWithVariadics_ :\
 > &nbsp;&nbsp; ( _NamedFunctionParam_ `,` )<sup>\*</sup> _NamedFunctionParam_ `,` `...`
 
-External blocks form the basis for Rust's foreign function interface.
-Declarations in an external block describe symbols in external libraries.
+External blocks provide _declarations_ of items that are not _defined_ in the
+current crate and are the basis of Rust's foreign function interface. Using
+items declared in external blocks is `unsafe`.
+
+Two kind of item _declarations_ are allowed in external blocks:
+[functions](function.md) and [statics](static-items.md).
 
 Functions within external blocks are declared in the same way as other Rust
 functions, with the exception that they may not have a body and are instead
@@ -47,6 +51,8 @@ extern "abi" for<'l1, ..., 'lm> fn(A1, ..., An) -> R`, where `'l1`, ... `'lm`
 are its lifetime parameters, `A1`, ..., `An` are the declared types of its
 parameters and `R` is the declared return type.
 
+Statics within external blocks are declared in the same way as other Rust statics,
+with the exception that they may not have an expression initializing their value.
 It is `unsafe` to access a static item declared in an extern block, whether or
 not it's mutable.
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -30,11 +30,12 @@
 > &nbsp;&nbsp; ( _NamedFunctionParam_ `,` )<sup>\*</sup> _NamedFunctionParam_ `,` `...`
 
 External blocks provide _declarations_ of items that are not _defined_ in the
-current crate and are the basis of Rust's foreign function interface. Using
-items declared in external blocks is only allowed in an `unsafe` context.
+current crate and are the basis of Rust's foreign function interface. These are
+sort of like unchecked imports. 
 
-Two kind of item _declarations_ are allowed in external blocks:
-[functions] and [statics].
+Two kind of item _declarations_ are allowed in external blocks: [functions] and
+[statics]. Calling functions or accessing statics that are declared in external
+blocks is only allowed in an `unsafe` context.
 
 Functions within external blocks are declared in the same way as other Rust
 functions, with the exception that they may not have a body and are instead

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -90,13 +90,6 @@ There are also some platform-specific ABI strings:
 * `extern "vectorcall"` -- The `vectorcall` ABI -- corresponds to MSVC's
   `__vectorcall` and clang's `__attribute__((vectorcall))`
 
-Finally, there are some unstable rustc-specific ABI strings:
-
-* `extern "rust-intrinsic"` -- The ABI of rustc intrinsics, equivalent to `"Rust"`.
-* `extern "rust-call"` -- The ABI of the Fn::call trait functions, equivalent to `"Rust"`.
-* `extern "platform-intrinsic"` -- The ABI of Specific platform intrinsics, equivalent to `"Rust"` -- like, for
-  example, `sqrt` -- equivalent to `"Rust"`. You should never have to deal with it.
-
 ## Variadic functions
 
 Functions within external blocks may be variadic by specifying `...` after one

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -31,7 +31,7 @@
 
 External blocks provide _declarations_ of items that are not _defined_ in the
 current crate and are the basis of Rust's foreign function interface. Using
-items declared in external blocks is `unsafe`.
+items declared in external blocks is only allowed in an `unsafe` context.
 
 Two kind of item _declarations_ are allowed in external blocks:
 [functions] and [statics].

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -30,8 +30,7 @@
 > &nbsp;&nbsp; ( _NamedFunctionParam_ `,` )<sup>\*</sup> _NamedFunctionParam_ `,` `...`
 
 External blocks form the basis for Rust's foreign function interface.
-Declarations in an external block describe symbols in external, non-Rust
-libraries.
+Declarations in an external block describe symbols in external libraries.
 
 Functions within external blocks are declared in the same way as other Rust
 functions, with the exception that they may not have a body and are instead

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -31,7 +31,7 @@
 
 External blocks provide _declarations_ of items that are not _defined_ in the
 current crate and are the basis of Rust's foreign function interface. These are
-sort of like unchecked imports. 
+akin to unchecked imports. 
 
 Two kind of item _declarations_ are allowed in external blocks: [functions] and
 [statics]. Calling functions or accessing statics that are declared in external

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -85,12 +85,12 @@ There are also some platform-specific ABI strings:
 * `extern "vectorcall"` -- The `vectorcall` ABI -- corresponds to MSVC's
   `__vectorcall` and clang's `__attribute__((vectorcall))`
 
-Finally, there are some rustc-specific ABI strings:
+Finally, there are some unstable rustc-specific ABI strings:
 
-* `extern "rust-intrinsic"` -- The ABI of rustc intrinsics.
-* `extern "rust-call"` -- The ABI of the Fn::call trait functions.
-* `extern "platform-intrinsic"` -- Specific platform intrinsics -- like, for
-  example, `sqrt` -- have this ABI. You should never have to deal with it.
+* `extern "rust-intrinsic"` -- The ABI of rustc intrinsics, equivalent to `"Rust"`.
+* `extern "rust-call"` -- The ABI of the Fn::call trait functions, equivalent to `"Rust"`.
+* `extern "platform-intrinsic"` -- The ABI of Specific platform intrinsics, equivalent to `"Rust"` -- like, for
+  example, `sqrt` -- equivalent to `"Rust"`. You should never have to deal with it.
 
 ## Variadic functions
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -53,7 +53,7 @@ are its lifetime parameters, `A1`, ..., `An` are the declared types of its
 parameters and `R` is the declared return type.
 
 Statics within external blocks are declared in the same way as statics outside of external blocks,
-with the exception that they may not have an expression initializing their value.
+except that they do not have an expression initializing their value.
 It is `unsafe` to access a static item declared in an extern block, whether or
 not it's mutable.
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -52,7 +52,7 @@ extern "abi" for<'l1, ..., 'lm> fn(A1, ..., An) -> R`, where `'l1`, ... `'lm`
 are its lifetime parameters, `A1`, ..., `An` are the declared types of its
 parameters and `R` is the declared return type.
 
-Statics within external blocks are declared in the same way as other Rust statics,
+Statics within external blocks are declared in the same way as statics outside of external blocks,
 with the exception that they may not have an expression initializing their value.
 It is `unsafe` to access a static item declared in an extern block, whether or
 not it's mutable.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -34,7 +34,7 @@ current crate and are the basis of Rust's foreign function interface. Using
 items declared in external blocks is `unsafe`.
 
 Two kind of item _declarations_ are allowed in external blocks:
-[functions](function.md) and [statics](static-items.md).
+[functions] and [statics].
 
 Functions within external blocks are declared in the same way as other Rust
 functions, with the exception that they may not have a body and are instead
@@ -170,6 +170,8 @@ extern {
 
 [IDENTIFIER]: ../identifiers.md
 [WebAssembly module]: https://webassembly.github.io/spec/core/syntax/modules.html
+[functions]: functions.md
+[statics]: static-items.md
 [_Abi_]: functions.md
 [_FunctionReturnType_]: functions.md
 [_Generics_]: generics.md

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -107,21 +107,28 @@ component after the function name. This might be necessary if there is not
 sufficient context to determine the type parameters. For example,
 `mem::size_of::<u32>() == 4`.
 
-## Extern functions
+## Extern function qualifier
 
-Extern function _definitions_ allow defining functions that can be called 
-with a particular ABI:
+The `extern` function qualifier allows providing function _definitions_ that can
+be called with a particular ABI:
 
 ```rust,ignore
 extern "ABI" fn foo() { ... }
 ```
 
-An extern function _declaration_ via an [external block] can be used to
-provide an item for these functions that can be called by Rust code without
-providing their definition. 
+These are often used in combination with [external block] items which provide
+function _declarations_ that can be used to call functions without providing
+their _definition_:
 
-When `"extern" Abi?*` is omitted from `FunctionQualifiers`, the ABI `"Rust"` is
-assigned. For example: 
+```rust,ignore
+extern "ABI" {
+  fn foo(); /* no body */
+}
+unsafe { foo() }
+```
+
+When `"extern" Abi?*` is omitted from `FunctionQualifiers` in function items,
+the ABI `"Rust"` is assigned. For example:
 
 ```rust
 fn foo() {}

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -112,7 +112,7 @@ sufficient context to determine the type parameters. For example,
 Extern function _definitions_ allow defining functions that can be called 
 with a particular ABI:
 
-```rust,no_run
+```rust,ignore
 extern "ABI" fn foo() { ... }
 ```
 
@@ -173,8 +173,9 @@ equivalent to the `"Rust"` ABI, e.g.,
 [`"rust-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/intrinsics.html?highlight=rust-intrin#intrinsics)
 or
 [`"platform-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/platform-intrinsics.html).
-Refer to the [Unstable Book](https://doc.rust-lang.org/unstable-book) for more
-information about these.
+For more information about these refer to the [ABI section of external block
+items][external-blocks.md#ABI] and the [Unstable
+Book](https://doc.rust-lang.org/unstable-book).
 
 ## Const functions
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -176,13 +176,10 @@ with such ABIs causes the process to abort.
 aborts the process by executing an illegal instruction.
 
 **Non-normative note**: There are other ABIs available in unstable Rust that are
-equivalent to the `"Rust"` ABI, e.g.,
-[`"rust-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/intrinsics.html?highlight=rust-intrin#intrinsics)
-or
-[`"platform-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/platform-intrinsics.html).
-For more information about these refer to the [ABI section of external block
-items][external-blocks.md#ABI] and the [Unstable
-Book](https://doc.rust-lang.org/unstable-book).
+equivalent to the `"Rust"` ABI, e.g., [`"rust-intrinsic"`][rust_intrinsic] or
+[`"platform-intrinsic"`][platform_intrinsic]. For more information about these
+refer to the [ABI section of external block items][external_block_abi] and the
+[Unstable Book].
 
 ## Const functions
 
@@ -290,3 +287,7 @@ attributes macros.
 [`export_name`]: ../abi.md#the-export_name-attribute
 [`link_section`]: ../abi.md#the-link_section-attribute
 [`no_mangle`]: ../abi.md#the-no_mangle-attribute
+[external_block_abi]: external-blocks.md#abi
+[Unstable Book]: https://doc.rust-lang.org/unstable-book
+[rust_intrinsic]: https://doc.rust-lang.org/unstable-book/language-features/intrinsics.html?highlight=rust-intrin#intrinsics
+[platform_intrinsic]: https://doc.rust-lang.org/unstable-book/language-features/platform-intrinsics.html

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -112,7 +112,7 @@ sufficient context to determine the type parameters. For example,
 Extern function _definitions_ allow defining functions that can be called 
 with a particular ABI:
 
-```rust,norun
+```rust,no_run
 extern "ABI" fn foo() { ... }
 ```
 
@@ -120,15 +120,14 @@ An extern function _declaration_ via an [external block] can be used to
 provide an item for these functions that can be called by Rust code without
 providing their definition. 
 
-The default ABI of Rust functions like `fn foo() {}` is `"Rust"`. While we
-abbreviate the type of Rust functions like `foo` as `fn()`, this is actually a 
-synonym for `extern "Rust" fn()`. That is, this:
+When `"extern" Abi?*` is omitted from `FunctionQualifiers`, the ABI `"Rust"` is
+assigned. For example: 
 
 ```rust
 fn foo() {}
 ```
 
-is identical to 
+is equivalent to:
 
 ```rust
 extern "Rust" fn foo() {}
@@ -148,30 +147,34 @@ extern "stdcall" fn new_i32_stdcall() -> i32 { 0 }
 ```
 
 Just as with [external block], when the `extern` keyword is used and the `"ABI` 
-is omitted, the ABI used defaults to `"C"`. That is, this
+is omitted, the ABI used defaults to `"C"`. That is, this:
 
 ```rust
 extern fn new_i32() -> i32 { 0 }
 let fptr: extern fn() -> i32 = new_i32;
 ```
 
-is identical to
+is equivalent to:
 
 ```rust
 extern "C" fn new_i32() -> i32 { 0 }
 let fptr: extern "C" fn() -> i32 = new_i32;
 ```
 
-Since functions with an ABI that differs from `"Rust"` do not support 
-unwinding in the exact same way that Rust does, unwinding past the end 
-of functions with such ABIs causes the process to abort. In LLVM, this is
-implemented by executing an illegal instruction.
+Functions with an ABI that differs from `"Rust"` do not support unwinding in the
+exact same way that Rust does. Therefore, unwinding past the end of functions
+with such ABIs causes the process to abort.
 
-Some ABIs that are identical to `"Rust"` are:
+**Non-normative note**: The LLVM backend of the current Rust implementation
+aborts the process by executing an illegal instruction.
 
-* `"rust-call"`
-* `"platform-intrinsic"`
-* `"rust-intrinsic"`
+**Non-normative note**: There are other ABIs available in unstable Rust that are
+equivalent to the `"Rust"` ABI, e.g.,
+[`"rust-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/intrinsics.html?highlight=rust-intrin#intrinsics)
+or
+[`"platform-intrinsic"`](https://doc.rust-lang.org/unstable-book/language-features/platform-intrinsics.html).
+Refer to the [Unstable Book](https://doc.rust-lang.org/unstable-book) for more
+information about these.
 
 ## Const functions
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -172,7 +172,7 @@ Functions with an ABI that differs from `"Rust"` do not support unwinding in the
 exact same way that Rust does. Therefore, unwinding past the end of functions
 with such ABIs causes the process to abort.
 
-**Non-normative note**: The LLVM backend of the current Rust implementation
+> **Note**: The LLVM backend of the `rustc` implementation
 aborts the process by executing an illegal instruction.
 
 ## Const functions

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -282,6 +282,3 @@ attributes macros.
 [`link_section`]: ../abi.md#the-link_section-attribute
 [`no_mangle`]: ../abi.md#the-no_mangle-attribute
 [external_block_abi]: external-blocks.md#abi
-[Unstable Book]: https://doc.rust-lang.org/unstable-book
-[rust_intrinsic]: https://doc.rust-lang.org/unstable-book/language-features/intrinsics.html?highlight=rust-intrin#intrinsics
-[platform_intrinsic]: https://doc.rust-lang.org/unstable-book/language-features/platform-intrinsics.html

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -175,12 +175,6 @@ with such ABIs causes the process to abort.
 **Non-normative note**: The LLVM backend of the current Rust implementation
 aborts the process by executing an illegal instruction.
 
-**Non-normative note**: There are other ABIs available in unstable Rust that are
-equivalent to the `"Rust"` ABI, e.g., [`"rust-intrinsic"`][rust_intrinsic] or
-[`"platform-intrinsic"`][platform_intrinsic]. For more information about these
-refer to the [ABI section of external block items][external_block_abi] and the
-[Unstable Book].
-
 ## Const functions
 
 Functions qualified with the `const` keyword are const functions. _Const

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -51,6 +51,6 @@ x = bo(5,7);
 [_Type_]: ../types.md#type-expressions
 [`extern`]: ../items/external-blocks.md
 [closures]: closure.md
-[extern function]: ../items/functions.md#extern-functions
+[extern function]: ../items/functions.md#extern-function-qualifier
 [function items]: function-item.md
 [unsafe function]: ../unsafe-functions.md


### PR DESCRIPTION
The current reference of extern functions definitions is incorrect. It doesn't take into account that all "normal" Rust functions are `extern "Rust" fn`.

The section about external blocks specifies that only "non-Rust functions" (whatever that means) can be declared in external blocks. This is incorrect, since both an `extern "C"` Rust function, and a function with the `"Rust"` ABI, can be declared in external blocks.