### PR TITLE
Fix warning in stable-check

### DIFF
--- a/stable-check/Cargo.toml
+++ b/stable-check/Cargo.toml
@@ -2,5 +2,4 @@
 name = "stable-check"
 version = "0.1.0"
 authors = ["steveklabnik <steve@steveklabnik.com>"]
-
-[dependencies]
+edition = "2018"

--- a/stable-check/src/main.rs
+++ b/stable-check/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     }
 }
 
-fn check_directory(dir: &Path) -> Result<(), Box<Error>> {
+fn check_directory(dir: &Path) -> Result<(), Box<dyn Error>> {
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();


### PR DESCRIPTION
Building stable-check with Rust 2015 prints a warning saying that in Rust 2018 `dyn Error` instead of `Error` is required. This sets the edition of `stable-check` to 2018 and fixes the warning.