### PR TITLE
update UB

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -44,15 +44,15 @@ code.
   * A `!` (all values are invalid for this type).
   * [Uninitialized memory][undef] in the value of an integer (`i*`/`u*`),
     floating point value (`f*`), or raw pointer.
-  * A dangling or unaligned reference or `Box`, or one that points to an invalid value.
+  * A reference or `Box<T>` that is dangling, unaligned, or points to an invalid value.
   * Invalid metadata in a wide reference, `Box`, or raw pointer:
     * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for
-      `Trait` that matches the actual dynamic trait the reference points to.
+      `Trait` that matches the actual dynamic trait the pointer or reference points to.
     * Slice metadata is invalid if if the length is not a valid `usize`
       (i.e., it must not be read from uninitialized memory).
   * Non-UTF-8 byte sequences in a `str`.
   * Invalid values for a type with a custom definition of invalid values, such
-    as a `NonNull` that is null. (Requesting custom invalid values is an
+    as a `NonNull<T>` that is null. (Requesting custom invalid values is an
     unstable feature, but some stable libstd types, like `NonNull`, make use of
     it.)
 
@@ -67,7 +67,7 @@ points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
 pointer value and the size of the pointee type. As a consequence, if the span is
 empty, "dangling" is the same as "non-null". Note that slices point to their
-entire range, so it is very important that the length metadata is never too
+entire range, so it is important that the length metadata is never too
 large. In particular, allocations and therefore slices cannot be bigger than
 `isize::MAX` bytes.
 

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -57,12 +57,6 @@ code.
     > **Note**: For `rustc`, those types are [`NonNull<T>`] and [`NonZero*`].
     > Requesting custom invalid types requires the unstable `rustc_layout_scalar_valid_range_*` attributes.
 
-> **Note**: Undefined behavior affects the entire program. For example, calling
-> a function in C that exhibits undefined behavior of C means your entire
-> program contains undefined behaviour that can also affect the Rust code. And
-> vice versa, undefined behavior in Rust can cause adverse affects on code
-> executed by any FFI calls to other languages.
-
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
@@ -71,6 +65,12 @@ empty, "dangling" is the same as "non-null". Note that slices point to their
 entire range, so it is important that the length metadata is never too
 large. In particular, allocations and therefore slices cannot be bigger than
 `isize::MAX` bytes.
+
+> **Note**: Undefined behavior affects the entire program. For example, calling
+> a function in C that exhibits undefined behavior of C means your entire
+> program contains undefined behaviour that can also affect the Rust code. And
+> vice versa, undefined behavior in Rust can cause adverse affects on code
+> executed by any FFI calls to other languages.
 
 [noalias]: http://llvm.org/docs/LangRef.html#noalias
 [pointer aliasing rules]: http://llvm.org/docs/LangRef.html#pointer-aliasing-rules

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -26,7 +26,7 @@ code.
 * Dereferencing (using the `*` operator on) a dangling or unaligned raw pointer.
 * Breaking the [pointer aliasing rules]. `&mut T` and `&T` follow LLVM’s scoped
   [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
-* Mutating immutable data. All data inside a `const` is immutable. Moreover, all
+* Mutating immutable data. All data inside a [`const`] item is immutable. Moreover, all
   data reached through a shared reference or data owned by an immutable binding
   is immutable, unless that data is contained within an [`UnsafeCell<U>`].
 * Invoking undefined behavior via compiler intrinsics.
@@ -73,6 +73,7 @@ large. In particular, allocations and therefore slices cannot be bigger than
 > vice versa, undefined behavior in Rust can cause adverse affects on code
 > executed by any FFI calls to other languages.
 
+[`const`]: items/constant-items.html
 [noalias]: http://llvm.org/docs/LangRef.html#noalias
 [pointer aliasing rules]: http://llvm.org/docs/LangRef.html#pointer-aliasing-rules
 [undef]: http://llvm.org/docs/LangRef.html#undefined-values

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -52,10 +52,10 @@ code.
     * Slice metadata is invalid if if the length is not a valid `usize`
       (i.e., it must not be read from uninitialized memory).
   * Non-UTF-8 byte sequences in a `str`.
-  * Invalid values for a type with a custom definition of invalid values, such
-    as a `NonNull<T>` that is null. (Requesting custom invalid values is an
-    unstable feature, but some stable libstd types, like `NonNull`, make use of
-    it.)
+  * Invalid values for a type with a custom definition of invalid values.
+
+    > **Note**: For `rustc`, those types are [`NonNull<T>`] and [`NonZero*`].
+    > Requesting custom invalid types requires the unstable `rustc_layout_scalar_valid_range_*` attributes.
 
 > **Note**: Undefined behavior affects the entire program. For example, calling
 > a function in C that exhibits undefined behavior of C means your entire
@@ -78,3 +78,5 @@ large. In particular, allocations and therefore slices cannot be bigger than
 [`target_feature`]: attributes/codegen.md#the-target_feature-attribute
 [`UnsafeCell<U>`]: ../std/cell/struct.UnsafeCell.html
 [Rustonomicon]: ../nomicon/index.html
+[`NonNull<T>`]: ../core/ptr/struct.NonNull.html
+[`NonZero*`]: ../core/num/index.html

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -32,7 +32,7 @@ code.
 * Invoking undefined behavior via compiler intrinsics.
 * Executing code compiled with platform features that the current platform
   does not support (see [`target_feature`]).
-* Calling a function with the wrong call ABI (including unwind ABI).
+* Calling a function with the wrong call ABI (in particular, with the wrong unwind ABI).
 * Producing an invalid value, even in private fields and locals. "Producing" a
   value happens any time a value is assigned to or read from a place, passed to
   a function/primitive operation or returned from a function/primitive

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -27,7 +27,7 @@ code.
 * Breaking the [pointer aliasing rules]. `&mut T` and `&T` follow LLVM’s scoped
   [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
 * Mutating non-mutable data (that is, data reached through a shared
-  reference or data owned by a `let` binding), unless that data is contained
+  reference or data owned by an immutable binding), unless that data is contained
   within an [`UnsafeCell<U>`].
 * Invoking undefined behavior via compiler intrinsics.
 * Executing code compiled with platform features that the current platform

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -53,9 +53,10 @@ code.
       (i.e., it must not be read from uninitialized memory).
   * Non-UTF-8 byte sequences in a `str`.
   * Invalid values for a type with a custom definition of invalid values.
+    In the standard library, this affects [`NonNull<T>`] and [`NonZero*`].
 
-    > **Note**: For `rustc`, those types are [`NonNull<T>`] and [`NonZero*`].
-    > Requesting custom invalid values requires the unstable `rustc_layout_scalar_valid_range_*` attributes.
+    > **Note**: For `rustc`, requesting custom invalid values requires the
+    > unstable `rustc_layout_scalar_valid_range_*` attributes.
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -42,15 +42,15 @@ code.
   * A null `fn` pointer.
   * A value in a `char` which is a surrogate or above `char::MAX`.
   * A `!` (all values are invalid for this type).
-  * A dangling or unaligned reference or `Box`, or one that points to an invalid value.
-  * Invalid metadata in a wide reference, `Box` or raw pointer:
-    * slice metadata is invalid if the slice has a total size larger than
-      `isize::MAX` bytes in memory.
-    * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for
-      `Trait` that matches the actual dynamic trait the reference points to.
-  * Non-UTF-8 byte sequences in a `str`.
   * [Uninitialized memory][undef] in the value of an integer (`i*`/`u*`),
     floating point value (`f*`), or raw pointer.
+  * A dangling or unaligned reference or `Box`, or one that points to an invalid value.
+  * Invalid metadata in a wide reference, `Box`, or raw pointer:
+    * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for
+      `Trait` that matches the actual dynamic trait the reference points to.
+    * Slice metadata is invalid if if the length is not a valid `usize`
+      (i.e., it must not be read from uninitialized memory).
+  * Non-UTF-8 byte sequences in a `str`.
   * Invalid values for a type with a custom definition of invalid values, such
     as a `NonNull` that is null. (Requesting custom invalid values is an
     unstable feature, but some stable libstd types, like `NonNull`, make use of
@@ -68,7 +68,8 @@ part of *some* allocation). The span of bytes it points to is determined by the
 pointer value and the size of the pointee type. As a consequence, if the span is
 empty, "dangling" is the same as "non-null". Note that slices point to their
 entire range, so it is very important that the length metadata is never too
-large.
+large. In particular, allocations and therefore slices cannot be bigger than
+`isize::MAX` bytes.
 
 [noalias]: http://llvm.org/docs/LangRef.html#noalias
 [pointer aliasing rules]: http://llvm.org/docs/LangRef.html#pointer-aliasing-rules

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -32,7 +32,7 @@ code.
 * Invoking undefined behavior via compiler intrinsics.
 * Executing code compiled with platform features that the current platform
   does not support (see [`target_feature`]).
-* Calling a function with the wrong call ABI (in particular, with the wrong unwind ABI).
+* Calling a function with the wrong call ABI or wrong unwind ABI.
 * Producing an invalid value, even in private fields and locals. "Producing" a
   value happens any time a value is assigned to or read from a place, passed to
   a function/primitive operation or returned from a function/primitive

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -55,7 +55,7 @@ code.
   * Invalid values for a type with a custom definition of invalid values.
 
     > **Note**: For `rustc`, those types are [`NonNull<T>`] and [`NonZero*`].
-    > Requesting custom invalid types requires the unstable `rustc_layout_scalar_valid_range_*` attributes.
+    > Requesting custom invalid values requires the unstable `rustc_layout_scalar_valid_range_*` attributes.
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -26,9 +26,9 @@ code.
 * Dereferencing (using the `*` operator on) a dangling or unaligned raw pointer.
 * Breaking the [pointer aliasing rules]. `&mut T` and `&T` follow LLVM’s scoped
   [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
-* Mutating non-mutable data (that is, data reached through a shared
-  reference or data owned by an immutable binding), unless that data is contained
-  within an [`UnsafeCell<U>`].
+* Mutating immutable data. All data inside a `const` is immutable. Moreover, all
+  data reached through a shared reference or data owned by an immutable binding
+  is immutable, unless that data is contained within an [`UnsafeCell<U>`].
 * Invoking undefined behavior via compiler intrinsics.
 * Executing code compiled with platform features that the current platform
   does not support (see [`target_feature`]).

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -32,7 +32,7 @@ code.
 * Invoking undefined behavior via compiler intrinsics.
 * Executing code compiled with platform features that the current platform
   does not support (see [`target_feature`]).
-* Unwinding into another language.
+* Calling a function with the wrong call ABI (including unwind ABI).
 * Producing an invalid value, even in private fields and locals. "Producing" a
   value happens any time a value is assigned to or read from a place, passed to
   a function/primitive operation or returned from a function/primitive

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -55,8 +55,8 @@ code.
   * Invalid values for a type with a custom definition of invalid values.
     In the standard library, this affects [`NonNull<T>`] and [`NonZero*`].
 
-    > **Note**: For `rustc`, requesting custom invalid values requires the
-    > unstable `rustc_layout_scalar_valid_range_*` attributes.
+    > **Note**: `rustc` achieves this with the unstable
+    > `rustc_layout_scalar_valid_range_*` attributes.
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -43,8 +43,8 @@ code.
   * A null `fn` pointer.
   * A value in a `char` which is a surrogate or above `char::MAX`.
   * A `!` (all values are invalid for this type).
-  * [Uninitialized memory][undef] in the value of an integer (`i*`/`u*`),
-    floating point value (`f*`), or raw pointer.
+  * An integer (`i*`/`u*`), floating point value (`f*`), or raw pointer obtained
+    from [uninitialized memory][undef].
   * A reference or `Box<T>` that is dangling, unaligned, or points to an invalid value.
   * Invalid metadata in a wide reference, `Box<T>`, or raw pointer:
     * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -34,8 +34,9 @@ code.
   does not support (see [`target_feature`]).
 * Unwinding into another language.
 * Producing an invalid value, even in private fields and locals. "Producing" a
-  value happens any time a value is assigned, passed to a function/primitive
-  operation or returned from a function/primitive operation.
+  value happens any time a value is assigned to or read from a place, passed to
+  a function/primitive operation or returned from a function/primitive
+  operation.
   The following values are invalid (at their respective type):
   * A value other than `false` (`0`) or `true` (`1`) in a `bool`.
   * A discriminant in an `enum` not included in the type definition.
@@ -45,7 +46,7 @@ code.
   * [Uninitialized memory][undef] in the value of an integer (`i*`/`u*`),
     floating point value (`f*`), or raw pointer.
   * A reference or `Box<T>` that is dangling, unaligned, or points to an invalid value.
-  * Invalid metadata in a wide reference, `Box`, or raw pointer:
+  * Invalid metadata in a wide reference, `Box<T>`, or raw pointer:
     * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for
       `Trait` that matches the actual dynamic trait the pointer or reference points to.
     * Slice metadata is invalid if if the length is not a valid `usize`


### PR DESCRIPTION
This syncs the Reference definition of UB with what the Nomicon has [recently been updated to](https://github.com/rust-lang-nursery/nomicon/pull/149), including the still-under-review changes in https://github.com/rust-lang-nursery/nomicon/pull/162.

Cc @Centril @Gankra 