### PR TITLE
Specify refutability of patterns in let and if let

### DIFF
--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -53,10 +53,11 @@ assert_eq!(y, "Bigger");
 
 An `if let` expression is semantically similar to an `if` expression but in
 place of a condition expression it expects the keyword `let` followed by a
-pattern, an `=` and a [scrutinee] expression. If the value of the scrutinee
-matches the pattern, the corresponding block will execute. Otherwise, flow
-proceeds to the following `else` block if it exists. Like `if` expressions,
-`if let` expressions have a value determined by the block that is evaluated.
+refutable or irrefutable pattern, an `=` and a [scrutinee] expression. If the
+value of the scrutinee matches the pattern, the corresponding block will
+execute. Otherwise, flow proceeds to the following `else` block if it
+exists. Like `if` expressions, `if let` expressions have a value determined
+by the block that is evaluated.
 
 ```rust
 let dish = ("Ham", "Eggs");

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -71,11 +71,11 @@ while i < 10 {
 >              [_BlockExpression_]
 
 A `while let` loop is semantically similar to a `while` loop but in place of a
-condition expression it expects the keyword `let` followed by a pattern, an
-`=`, a [scrutinee] expression and a block expression. If the value of the
-scrutinee matches the pattern, the loop body block executes then control
-returns to the pattern matching statement. Otherwise, the while expression
-completes.
+condition expression it expects the keyword `let` followed by a refutable or
+irrefutable pattern, an `=`, a [scrutinee] expression and a block expression.
+If the value of the scrutinee matches the pattern, the loop body block executes
+then control returns to the pattern matching statement. Otherwise, the while
+expression completes.
 
 ```rust
 let mut x = vec![1, 2, 3];
@@ -130,9 +130,9 @@ while let Some(v @ 1) | Some(v @ 2) = vals.pop() {
 
 A `for` expression is a syntactic construct for looping over elements provided
 by an implementation of `std::iter::IntoIterator`. If the iterator yields a
-value, that value is given the specified name and the body of the loop is
-executed, then control returns to the head of the `for` loop. If the iterator
-is empty, the `for` expression completes.
+value, that value is assigned to the irrefutable pattern, the body of the
+loop is executed and then control returns to the head of the `for` loop. If the
+iterator is empty, the `for` expression completes.
 
 An example of a `for` loop over the contents of an array:
 

--- a/src/statements.md
+++ b/src/statements.md
@@ -56,13 +56,13 @@ fn outer() {
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> `let` [_Pattern_]
 >     ( `:` [_Type_] )<sup>?</sup> (`=` [_Expression_] )<sup>?</sup> `;`
 
-A *`let` statement* introduces a new set of [variables], given by a [pattern]. The
-pattern is followed optionally by a type annotation and then optionally by an
-initializer expression. When no type annotation is given, the compiler will
-infer the type, or signal an error if insufficient type information is
-available for definite inference. Any variables introduced by a variable
-declaration are visible from the point of declaration until the end of the
-enclosing block scope.
+A *`let` statement* introduces a new set of [variables], given by an
+irrefutable [pattern]. The pattern is followed optionally by a type
+annotation and then optionally by an initializer expression. When no
+type annotation is given, the compiler will infer the type, or signal
+an error if insufficient type information is available for definite
+inference. Any variables introduced by a variable declaration are visible
+from the point of declaration until the end of the enclosing block scope.
 
 ## Expression statements
 


### PR DESCRIPTION
Specify that patterns in 'if let' expressions are refutable
while patterns in 'let' statements are irrefutable.