### PR TITLE
 Specify pattern types in `let` statements and `for` expressions

### DIFF
--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -130,9 +130,9 @@ while let Some(v @ 1) | Some(v @ 2) = vals.pop() {
 
 A `for` expression is a syntactic construct for looping over elements provided
 by an implementation of `std::iter::IntoIterator`. If the iterator yields a
-value, that value is given the specified name and the body of the loop is
-executed, then control returns to the head of the `for` loop. If the iterator
-is empty, the `for` expression completes.
+value, that value is matched against the irrefutable pattern, the body of the
+loop is executed, and then control returns to the head of the `for` loop. If the
+iterator is empty, the `for` expression completes.
 
 An example of a `for` loop over the contents of an array:
 

--- a/src/statements.md
+++ b/src/statements.md
@@ -56,13 +56,13 @@ fn outer() {
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> `let` [_Pattern_]
 >     ( `:` [_Type_] )<sup>?</sup> (`=` [_Expression_] )<sup>?</sup> `;`
 
-A *`let` statement* introduces a new set of [variables], given by a [pattern]. The
-pattern is followed optionally by a type annotation and then optionally by an
-initializer expression. When no type annotation is given, the compiler will
-infer the type, or signal an error if insufficient type information is
-available for definite inference. Any variables introduced by a variable
-declaration are visible from the point of declaration until the end of the
-enclosing block scope.
+A *`let` statement* introduces a new set of [variables], given by an
+irrefutable [pattern]. The pattern is followed optionally by a type
+annotation and then optionally by an initializer expression. When no
+type annotation is given, the compiler will infer the type, or signal
+an error if insufficient type information is available for definite
+inference. Any variables introduced by a variable declaration are visible
+from the point of declaration until the end of the enclosing block scope.
 
 ## Expression statements
 


### PR DESCRIPTION
Specify that patterns in
1. `if let` and `while let` are either refutable or irrefutable
2. `let` and `for` are always irrefutable