### PR TITLE
Fix #664: Review Oxford comma usage.

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -16,7 +16,7 @@
 > &nbsp;&nbsp; | `=` [_LiteralExpression_]<sub>_without suffix_</sub>
 
 An _attribute_ is a general, free-form metadatum that is interpreted according
-to name, convention, and language and compiler version. Attributes are modeled
+to name, convention, language, and compiler version. Attributes are modeled
 on Attributes in [ECMA-335], with the syntax coming from [ECMA-334] \(C#).
 
 _Inner attributes_, written with a bang (`!`) after the hash (`#`), apply to the

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -25,7 +25,7 @@
 *Conditionally compiled source code* is source code that may or may not be
 considered a part of the source code depending on certain conditions. <!-- This
 definition is sort of vacuous --> Source code can be conditionally compiled
-using [attributes], [`cfg`] and [`cfg_attr`], and the built-in [`cfg` macro].
+using the [attributes] [`cfg`] and [`cfg_attr`] and the built-in [`cfg` macro].
 These conditions are based on the target architecture of the compiled crate,
 arbitrary values passed to the compiler, and a few other miscellaneous things
 further described below in detail.

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -37,8 +37,8 @@ to be run.
 * Index expressions, [array indexing] or [slice] with a `usize`.
 * [Range expressions].
 * [Closure expressions] which don't capture variables from the environment.
-* Built in [negation], [arithmetic, logical], [comparison] or [lazy boolean]
-  operators used on integer and floating point types, `bool` and `char`.
+* Built-in [negation], [arithmetic], [logical], [comparison] or [lazy boolean]
+  operators used on integer and floating point types, `bool`, and `char`.
 * Shared [borrow]s, except if applied to a type with [interior mutability].
 * The [dereference operator].
 * [Grouped] expressions.
@@ -57,7 +57,7 @@ A _const context_ is one of the following:
   * [statics]
   * [enum discriminants]
 
-[arithmetic, logical]:  expressions/operator-expr.md#arithmetic-and-logical-binary-operators
+[arithmetic]:           expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [array expressions]:    expressions/array-expr.md
 [array indexing]:       expressions/array-expr.md#array-and-slice-indexing-expressions
 [array indexing]:       expressions/array-expr.md#array-and-slice-indexing-expressions
@@ -84,6 +84,7 @@ A _const context_ is one of the following:
 [lazy boolean]:         expressions/operator-expr.md#lazy-boolean-operators
 [let statements]:       statements.md#let-statements
 [literals]:             expressions/literal-expr.md
+[logical]:              expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [negation]:             expressions/operator-expr.md#negation-operators
 [overflow]:             expressions/operator-expr.md#overflow
 [paths]:                expressions/path-expr.md

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -29,7 +29,7 @@ crate in binary form: either an executable or some sort of
 library.[^cratesourcefile]
 
 A _crate_ is a unit of compilation and linking, as well as versioning,
-distribution and runtime loading. A crate contains a _tree_ of nested
+distribution, and runtime loading. A crate contains a _tree_ of nested
 [module] scopes. The top level of this tree is a module that is
 anonymous (from the point of view of paths within the module) and any item
 within a crate has a canonical [module path] denoting its location

--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -20,7 +20,7 @@ types">DSTs</abbr>. Such types can only be used in certain cases:
   last field, this makes the struct itself a
   <abbr title="dynamically sized type">DST</abbr>.
 
-Notably: [variables], function parameters, [const] and [static] items must be
+> **Note**: [variables], function parameters, [const] items, and [static] items must be
 `Sized`.
 
 [sized]: special-types-and-traits.md#sized

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -265,7 +265,7 @@ a few specific cases:
 
 * Before an expression used as a [statement].
 * Elements of [array expressions], [tuple expressions], [call expressions],
-  tuple-style [struct] and [enum variant] expressions.
+  and tuple-style [struct] and [enum variant] expressions.
   <!--
     These were likely stabilized inadvertently.
     See https://github.com/rust-lang/rust/issues/32796 and

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -180,7 +180,7 @@ expression in the following situations:
 * Loop bodies ([`loop`], [`while`], [`while let`], and [`for`]).
 * Block expressions used as a [statement].
 * Block expressions as elements of [array expressions], [tuple expressions],
-  [call expressions], tuple-style [struct] and [enum variant] expressions.
+  [call expressions], and tuple-style [struct] and [enum variant] expressions.
 * A block expression as the tail expression of another block expression.
 <!-- Keep list in sync with expressions.md -->
 

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -181,9 +181,9 @@ is equivalent to
 }
 ```
 
-`IntoIterator`, `Iterator` and `Option` are always the standard library items
+`IntoIterator`, `Iterator`, and `Option` are always the standard library items
 here, not whatever those names resolve to in the current scope. The variable
-names `next`, `iter` and `val` are for exposition only, they do not actually
+names `next`, `iter`, and `val` are for exposition only, they do not actually
 have names the user can type.
 
 > **Note**: that the outer `match` is used to ensure that any

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -5,7 +5,7 @@ provides three kinds of material:
 
   - Chapters that informally describe each language construct and their use.
   - Chapters that informally describe the memory model, concurrency model,
-    runtime services, linkage model and debugging facilities.
+    runtime services, linkage model, and debugging facilities.
   - Appendix chapters providing rationale and references to languages that
     influenced the design.
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -133,7 +133,7 @@ Shorthand             | Equivalent
 `&'lifetime self`     | `self: &'lifetime Self`
 `&'lifetime mut self` | `self: &'lifetime mut Self`
 
-> Note: Lifetimes can be and usually are elided with this shorthand.
+> **Note**: Lifetimes can be, and usually are, elided with this shorthand.
 
 If the `self` parameter is prefixed with `mut`, it becomes a mutable variable,
 similar to regular parameters using a `mut` [identifier pattern]. For example:

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -210,7 +210,7 @@ Exhaustive list of permitted structures in const functions:
     * lifetimes
     * `Sized` or [`?Sized`]
 
-    This means that `<T: 'a + ?Sized>`, `<T: 'b + Sized>` and `<T>`
+    This means that `<T: 'a + ?Sized>`, `<T: 'b + Sized>`, and `<T>`
     are all permitted.
 
     This rule also applies to type parameters of impl blocks that

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -20,7 +20,7 @@
 > _TypeParam_ :\
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>?</sup> [IDENTIFIER] ( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>
 
-Functions, type aliases, structs, enumerations, unions, traits and
+Functions, type aliases, structs, enumerations, unions, traits, and
 implementations may be *parameterized* by types and lifetimes. These parameters
 are listed in angle <span class="parenthetical">brackets (`<...>`)</span>,
 usually immediately after the name of the item and before its definition. For
@@ -34,7 +34,7 @@ trait A<U> {}
 struct Ref<'a, T> where T: 'a { r: &'a T }
 ```
 
-[References], [raw pointers], [arrays], [slices][arrays], [tuples] and
+[References], [raw pointers], [arrays], [slices][arrays], [tuples], and
 [function pointers] have lifetime or type parameters as well, but are not
 referred to with path syntax.
 
@@ -64,7 +64,7 @@ parameters.
 Bounds that don't use the item's parameters or higher-ranked lifetimes are
 checked when the item is defined. It is an error for such a bound to be false.
 
-[`Copy`], [`Clone`] and [`Sized`] bounds are also checked for certain generic
+[`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic
 types when defining the item. It is an error to have `Copy` or `Clone`as a
 bound on a mutable reference, [trait object] or [slice][arrays] or `Sized` as a
 bound on a trait object or slice.

--- a/src/items/unions.md
+++ b/src/items/unions.md
@@ -151,7 +151,7 @@ fn test() {
 }
 ```
 
-As you could see, in many aspects (except for layouts, safety and ownership)
+As you could see, in many aspects (except for layouts, safety, and ownership)
 unions behave exactly like structs, largely as a consequence of inheriting
 their syntactic shape from structs. This is also true for many unmentioned
 aspects of Rust language (such as privacy, name resolution, type inference,

--- a/src/lifetime-elision.md
+++ b/src/lifetime-elision.md
@@ -6,7 +6,7 @@ compiler can infer a sensible default choice.
 ## Lifetime elision in functions
 
 In order to make common patterns more ergonomic, lifetime arguments can be
-*elided* in [function item], [function pointer] and [closure trait] signatures.
+*elided* in [function item], [function pointer], and [closure trait] signatures.
 The following rules are used to infer lifetime parameters for elided lifetimes.
 It is an error to elide lifetime parameters that cannot be inferred. The
 placeholder lifetime, `'_`, can also be used to have a lifetime inferred in the

--- a/src/memory-allocation-and-lifetime.md
+++ b/src/memory-allocation-and-lifetime.md
@@ -1,6 +1,6 @@
 # Memory allocation and lifetime
 
-The _items_ of a program are those functions, modules and types that have their
+The _items_ of a program are those functions, modules, and types that have their
 value calculated at compile-time and stored uniquely in the memory image of the
 rust process. Items are neither dynamically allocated nor freed.
 

--- a/src/special-types-and-traits.md
+++ b/src/special-types-and-traits.md
@@ -38,13 +38,13 @@ mutability aren't placed in memory marked as read only.
 ## `PhantomData<T>`
 
 [`std::marker::PhantomData<T>`] is a zero-sized, minimum alignment, type that
-is considered to own a `T` for the purposes of [variance], [drop check] and
+is considered to own a `T` for the purposes of [variance], [drop check], and
 [auto traits](#auto-traits).
 
 ## Operator Traits
 
 The traits in [`std::ops`] and [`std::cmp`] are used to overload [operators],
-[indexing expressions] and [call expressions].
+[indexing expressions], and [call expressions].
 
 ## `Deref` and `DerefMut`
 
@@ -64,7 +64,7 @@ whose type implements `Copy` are copied rather than moved upon assignment.
 fields that are not `Copy`. `Copy` is implemented by the compiler for
 
 * [Numeric types]
-* `char`, `bool` and [`!`]
+* `char`, `bool`, and [`!`]
 * [Tuples] of `Copy` types
 * [Arrays] of `Copy` types
 * [Shared references]
@@ -94,17 +94,17 @@ immutable [`static` items].
 
 ## Auto traits
 
-The [`Send`], [`Sync`], [`UnwindSafe`] and [`RefUnwindSafe`] traits are _auto
+The [`Send`], [`Sync`], [`UnwindSafe`], and [`RefUnwindSafe`] traits are _auto
 traits_. Auto traits have special properties.
 
 If no explicit implementation or negative implementation is written out for an
 auto trait for a given type, then the compiler implements it automatically
 according to the following rules:
 
-* `&T`, `&mut T`, `*const T`, `*mut T`, `[T; n]` and `[T]` implement the trait
+* `&T`, `&mut T`, `*const T`, `*mut T`, `[T; n]`, and `[T]` implement the trait
   if `T` does.
 * Function item types and function pointers automatically implement the trait.
-* Structs, enums, unions and tuples implement the trait if all of their fields
+* Structs, enums, unions, and tuples implement the trait if all of their fields
   do.
 * Closures implement the trait if the types of all of their captures do. A
   closure that captures a `T` by shared reference and a `U` by value implements

--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -65,7 +65,7 @@ Variance of types is automatically determined as follows
 | `std::marker::PhantomData<T>` |                   | covariant         |
 | `Trait<T> + 'a`               | covariant         | invariant         |
 
-The variance of other `struct`, `enum`, `union` and tuple types is decided by
+The variance of other `struct`, `enum`, `union`, and tuple types is decided by
 looking at the variance of the types of their fields. If the parameter is used
 in positions with different variances then the parameter is invariant. For
 example the following struct is covariant in `'a` and `T` and invariant in `'b`

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -361,7 +361,7 @@ An _integer literal_ has one of four forms:
   mixture of *decimal digits* and _underscores_.
 * A _tuple index_ is either `0`, or starts with a *non-zero decimal digit* and
   continues with zero or more decimal digits. Tuple indexes are used to refer
-  to the fields of [tuples], [tuple structs] and [tuple variants].
+  to the fields of [tuples], [tuple structs], and [tuple variants].
 * A _hex literal_ starts with the character sequence `U+0030` `U+0078`
   (`0x`) and continues as any mixture (with at least one digit) of hex digits
   and underscores.
@@ -429,7 +429,7 @@ Examples of invalid integer literals:
 128_i8;
 256_u8;
 
-// bin, hex and octal literals must have at least one digit
+// bin, hex, and octal literals must have at least one digit
 
 0b_;
 0b____;

--- a/src/types.md
+++ b/src/types.md
@@ -1,7 +1,7 @@
 {{#include types-redirect.html}}
 # Types
 
-Every variable, item and value in a Rust program has a type. The _type_ of a
+Every variable, item, and value in a Rust program has a type. The _type_ of a
 *value* defines the interpretation of the memory holding it and the operations
 that may be performed on the value.
 
@@ -94,7 +94,7 @@ type T<'a> = &'a (dyn Any + Send);
 
 ## Recursive types
 
-Nominal types &mdash; [structs], [enumerations] and [unions] &mdash; may be
+Nominal types &mdash; [structs], [enumerations], and [unions] &mdash; may be
 recursive. That is, each `enum` variant or `struct` or `union` field may
 refer, directly or indirectly, to the enclosing `enum` or `struct` type
 itself. Such recursion has restrictions:


### PR DESCRIPTION
This is an update to correct for the places where the Oxford
comma is not used.