### PR TITLE
Fix match in union example.

### DIFF
--- a/src/items/unions.md
+++ b/src/items/unions.md
@@ -119,8 +119,8 @@ struct Value {
 fn is_zero(v: Value) -> bool {
     unsafe {
         match v {
-            Value { tag: I, u: U { i: 0 } } => true,
-            Value { tag: F, u: U { f: num } } if num == 0.0 => true,
+            Value { tag: Tag::I, u: U { i: 0 } } => true,
+            Value { tag: Tag::F, u: U { f: num } } if num == 0.0 => true,
             _ => false,
         }
     }


### PR DESCRIPTION
I think the intent here is to match on the variant. The current example is
binding variables named "I" and "F".